### PR TITLE
Add session detection for solo Claude Code sessions

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,15 +21,21 @@ app.get('/api/state', (_req, res) => {
   res.json(stateManager.getState());
 });
 
+// Sessions list endpoint
+app.get('/api/sessions', (_req, res) => {
+  res.json(stateManager.getSessionsList());
+});
+
 // WebSocket server
 const wss = new WebSocketServer({ server, path: '/ws' });
 
 wss.on('connection', (ws: WebSocket) => {
   console.log('[ws] client connected');
 
-  // Send current state on connect
+  // Send current state and sessions list on connect
   const state = stateManager.getState();
   ws.send(JSON.stringify({ type: 'full_state', data: state }));
+  ws.send(JSON.stringify({ type: 'sessions_list', data: stateManager.getSessionsList() }));
 
   // Subscribe to state changes
   const unsubscribe = stateManager.subscribe((msg) => {

--- a/packages/server/src/watcher.ts
+++ b/packages/server/src/watcher.ts
@@ -8,12 +8,23 @@ import {
   parseTaskFile,
   teamMemberToAgent,
   parseTranscriptLine,
+  parseSessionMetadata,
   readNewLines,
+  readFirstLine,
+  cleanProjectName,
 } from './parser';
 
 const CLAUDE_DIR = join(homedir(), '.claude');
 const TEAMS_DIR = join(CLAUDE_DIR, 'teams');
 const TASKS_DIR = join(CLAUDE_DIR, 'tasks');
+const PROJECTS_DIR = join(CLAUDE_DIR, 'projects');
+
+/** Seconds of inactivity before marking a session idle */
+const IDLE_THRESHOLD_S = 60;
+/** Seconds of inactivity before removing a session entirely */
+const REMOVE_THRESHOLD_S = 120;
+/** How often to check for stale sessions (ms) */
+const STALENESS_CHECK_INTERVAL_MS = 15_000;
 
 function createDebouncer(delayMs: number) {
   const timers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -47,12 +58,28 @@ async function isReadable(filePath: string): Promise<boolean> {
   }
 }
 
+/** Track which JSONL files map to which sessionId */
+interface TrackedSession {
+  sessionId: string;
+  filePath: string;
+  /** Whether this is a solo session (no teamName) */
+  isSolo: boolean;
+  /** Project directory slug from the file path */
+  dirSlug: string;
+  lastActivity: number;
+}
+
 export function startWatcher(stateManager: StateManager) {
   const fileOffsets = new Map<string, number>();
   const debouncer = createDebouncer(150);
   const transcriptDebouncer = createDebouncer(300);
 
-  // Watch team configs - watch directory, filter to config.json in handlers
+  /** Map from JSONL file path to session tracking info */
+  const trackedSessions = new Map<string, TrackedSession>();
+
+  // ================================================================
+  // Team config watcher
+  // ================================================================
   const teamWatcher = chokidar.watch(TEAMS_DIR, {
     ignoreInitial: false,
     persistent: true,
@@ -64,11 +91,11 @@ export function startWatcher(stateManager: StateManager) {
     console.log('[watcher] Team watcher ready');
   });
   teamWatcher.on('add', (fp: string) => {
-    if (basename(fp) !== 'config.json') return; // Filter to config.json only
+    if (basename(fp) !== 'config.json') return;
     debouncer.debounce(`team:${fp}`, () => handleTeamConfig(fp));
   });
   teamWatcher.on('change', (fp: string) => {
-    if (basename(fp) !== 'config.json') return; // Filter to config.json only
+    if (basename(fp) !== 'config.json') return;
     debouncer.debounce(`team:${fp}`, () => handleTeamConfig(fp));
   });
   teamWatcher.on('unlink', (fp: string) => {
@@ -92,7 +119,9 @@ export function startWatcher(stateManager: StateManager) {
     await scanTasks(teamName);
   }
 
-  // Watch task files (chokidar v4: watch dir, filter via ignored)
+  // ================================================================
+  // Task file watcher
+  // ================================================================
   const taskWatcher = chokidar.watch(TASKS_DIR, {
     ignoreInitial: false,
     persistent: true,
@@ -150,12 +179,13 @@ export function startWatcher(stateManager: StateManager) {
     }
   }
 
-  // Watch JSONL transcript files (chokidar v4: watch dir, filter via ignored)
-  const PROJECTS_DIR = join(CLAUDE_DIR, 'projects');
+  // ================================================================
+  // JSONL transcript watcher - now with session detection
+  // ================================================================
   const transcriptWatcher = chokidar.watch(PROJECTS_DIR, {
-    ignoreInitial: true,
+    ignoreInitial: false, // Changed: detect existing sessions on startup
     persistent: true,
-    depth: 2,
+    depth: 4, // Increased: catch subagent transcripts at {project}/{session}/subagents/*.jsonl
     awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 200 },
     ignored: (path: string, stats?: { isDirectory(): boolean }) => {
       if (stats?.isDirectory()) return false;
@@ -163,8 +193,13 @@ export function startWatcher(stateManager: StateManager) {
     },
   });
 
-  transcriptWatcher.on('add', (filePath: string) => {
+  transcriptWatcher.on('ready', () => {
+    console.log('[watcher] Transcript watcher ready');
+  });
+
+  transcriptWatcher.on('add', async (filePath: string) => {
     fileOffsets.set(filePath, 0);
+    await detectSession(filePath);
   });
 
   transcriptWatcher.on('change', (filePath: string) => {
@@ -173,16 +208,88 @@ export function startWatcher(stateManager: StateManager) {
 
   transcriptWatcher.on('unlink', (filePath: string) => {
     fileOffsets.delete(filePath);
+    const tracked = trackedSessions.get(filePath);
+    if (tracked) {
+      trackedSessions.delete(filePath);
+      // Only remove the session if no other files reference the same sessionId
+      const hasOtherFiles = [...trackedSessions.values()].some(
+        (t) => t.sessionId === tracked.sessionId
+      );
+      if (!hasOtherFiles && tracked.isSolo) {
+        removeSoloSession(tracked.sessionId);
+      }
+    }
   });
 
   transcriptWatcher.on('error', (err: unknown) => {
     console.warn('[watcher] Transcript watcher error:', err instanceof Error ? err.message : err);
   });
 
+  /**
+   * Read the first line of a newly detected JSONL file to extract session metadata.
+   * For solo sessions (no teamName), create a synthetic agent.
+   */
+  async function detectSession(filePath: string) {
+    const firstLine = await readFirstLine(filePath);
+    if (!firstLine) return;
+
+    const meta = parseSessionMetadata(firstLine);
+    if (!meta) return;
+
+    // Extract the project directory slug from the file path
+    // Path structure: ~/.claude/projects/{dirSlug}/{sessionId}.jsonl
+    // or ~/.claude/projects/{dirSlug}/{sessionId}/subagents/{agentId}.jsonl
+    const relPath = filePath.slice(PROJECTS_DIR.length + 1); // strip prefix + /
+    const dirSlug = relPath.split('/')[0] || '';
+
+    const tracked: TrackedSession = {
+      sessionId: meta.sessionId,
+      filePath,
+      isSolo: !meta.isTeam,
+      dirSlug,
+      lastActivity: Date.now(),
+    };
+    trackedSessions.set(filePath, tracked);
+
+    // If no projectName was derived from cwd, use the directory slug
+    if (!meta.projectName && dirSlug) {
+      meta.projectName = cleanProjectName(dirSlug);
+    }
+
+    // Register the session
+    const existingSessions = stateManager.getSessions();
+    if (!existingSessions.has(meta.sessionId)) {
+      console.log(
+        `[watcher] New session detected: ${meta.sessionId} (${meta.isTeam ? 'team' : 'solo'}) - ${meta.projectName}`
+      );
+      stateManager.setSession(meta);
+
+      // For solo sessions, create a synthetic agent
+      if (!meta.isTeam) {
+        const agentName = meta.slug || meta.projectName || 'claude';
+        stateManager.setTeamName(meta.projectName || cleanProjectName(dirSlug));
+        stateManager.updateAgent({
+          id: meta.sessionId,
+          name: agentName,
+          role: 'implementer',
+          status: 'working',
+          tasksCompleted: 0,
+        });
+      }
+    }
+  }
+
   async function handleTranscriptChange(filePath: string) {
     const offset = fileOffsets.get(filePath) ?? 0;
     const { lines, newOffset } = await readNewLines(filePath, offset);
     fileOffsets.set(filePath, newOffset);
+
+    // Update last activity time for the tracked session
+    const tracked = trackedSessions.get(filePath);
+    if (tracked) {
+      tracked.lastActivity = Date.now();
+      stateManager.updateSessionActivity(tracked.sessionId);
+    }
 
     for (const line of lines) {
       const parsed = parseTranscriptLine(line);
@@ -193,6 +300,17 @@ export function startWatcher(stateManager: StateManager) {
       }
 
       if (parsed.type === 'tool_call' && parsed.toolName) {
+        // For solo sessions, update the synthetic agent directly
+        if (tracked?.isSolo) {
+          stateManager.updateAgentActivity(
+            getSoloAgentName(tracked.sessionId),
+            'working',
+            parsed.toolName
+          );
+          continue;
+        }
+
+        // For team sessions, match to the right agent
         if (parsed.agentName) {
           const state = stateManager.getState();
           const agent = state.agents.find((a) => a.name === parsed.agentName);
@@ -209,15 +327,79 @@ export function startWatcher(stateManager: StateManager) {
           }
         }
       }
+
+      // For solo sessions, assistant/tool_result entries indicate activity
+      if (tracked?.isSolo && parsed.type === 'agent_activity') {
+        stateManager.updateAgentActivity(
+          getSoloAgentName(tracked.sessionId),
+          'working'
+        );
+      }
     }
   }
 
+  /**
+   * Get the agent name for a solo session.
+   * The agent uses the session's slug as its name.
+   */
+  function getSoloAgentName(sessionId: string): string {
+    const session = stateManager.getSessions().get(sessionId);
+    return session?.slug || session?.projectName || 'claude';
+  }
+
+  /**
+   * Remove a solo session's synthetic agent and session record.
+   */
+  function removeSoloSession(sessionId: string) {
+    console.log(`[watcher] Removing solo session: ${sessionId}`);
+    stateManager.removeAgent(sessionId);
+    stateManager.removeSession(sessionId);
+  }
+
+  // ================================================================
+  // Periodic staleness check for sessions
+  // ================================================================
+  const stalenessInterval = setInterval(() => {
+    const now = Date.now();
+
+    for (const [filePath, tracked] of trackedSessions) {
+      if (!tracked.isSolo) continue; // Only manage solo session lifecycle
+
+      const idleSeconds = (now - tracked.lastActivity) / 1000;
+
+      if (idleSeconds >= REMOVE_THRESHOLD_S) {
+        // Session is stale -- remove it
+        console.log(
+          `[watcher] Solo session ${tracked.sessionId} inactive for ${Math.round(idleSeconds)}s, removing`
+        );
+        trackedSessions.delete(filePath);
+        fileOffsets.delete(filePath);
+        // Only remove if no other files reference the same sessionId
+        const hasOtherFiles = [...trackedSessions.values()].some(
+          (t) => t.sessionId === tracked.sessionId
+        );
+        if (!hasOtherFiles) {
+          removeSoloSession(tracked.sessionId);
+        }
+      } else if (idleSeconds >= IDLE_THRESHOLD_S) {
+        // Mark the solo agent as idle
+        const agentName = getSoloAgentName(tracked.sessionId);
+        const state = stateManager.getState();
+        const agent = state.agents.find((a) => a.name === agentName);
+        if (agent && agent.status === 'working') {
+          stateManager.updateAgentActivity(agentName, 'idle');
+        }
+      }
+    }
+  }, STALENESS_CHECK_INTERVAL_MS);
+
   console.log(`[watcher] Watching ${TEAMS_DIR}`);
   console.log(`[watcher] Watching ${TASKS_DIR}`);
-  console.log(`[watcher] Watching transcripts in ${CLAUDE_DIR}/projects/`);
+  console.log(`[watcher] Watching transcripts in ${PROJECTS_DIR}`);
 
   return {
     close: () => {
+      clearInterval(stalenessInterval);
       debouncer.clear();
       transcriptDebouncer.clear();
       teamWatcher.close();


### PR DESCRIPTION
## Summary
- **Server-side session detection**: Watches JSONL transcript files in `~/.claude/projects/` to detect both solo and team Claude Code sessions
- **Solo agent visualization**: Creates synthetic agents for solo sessions (non-team) so they appear in the town view
- **Session lifecycle management**: Marks solo agents idle after 60s of inactivity, removes sessions after 120s
- **New API endpoint**: `/api/sessions` returns all detected sessions; `sessions_list` WebSocket messages keep clients updated

## Changes

### parser.ts
- `parseSessionMetadata()` - extracts sessionId, slug, cwd, gitBranch, teamName from JSONL lines
- `cleanProjectName()` - converts directory slugs like `-Users-Danny-Source-my-project` to `my-project`
- `readFirstLine()` - reads first line of a JSONL file for session detection

### state.ts
- Session tracking via `Map<sessionId, SessionInfo>`
- `setSession()`, `removeSession()`, `updateSessionActivity()` methods
- `getSessionsList()` returns `SessionListEntry[]` for the API/WebSocket
- `broadcastSessionsList()` sends `sessions_list` WS messages

### watcher.ts
- `ignoreInitial: false` to detect existing sessions on startup
- `depth: 4` to catch subagent transcripts at `{session}/subagents/*.jsonl`
- Session detection on JSONL `add` events via first-line metadata parsing
- Solo session agent creation with `role: 'implementer'`
- 15s staleness interval: idle at 60s, remove at 120s
- Tool call routing for solo sessions directly to synthetic agent

### index.ts
- `/api/sessions` REST endpoint
- Send `sessions_list` on WebSocket connect

### Tests
- 13 new tests for `cleanProjectName`, `parseSessionMetadata`, `readFirstLine`
- All 37 tests pass

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (37/37 tests)
- [ ] Manual test: run solo `claude` session, verify agent appears in town view
- [ ] Manual test: verify team sessions still work as before
- [ ] Manual test: verify idle/removal thresholds work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)