### PR TITLE
Add responsive design with mobile tab navigation

### DIFF
--- a/packages/client/src/components/Scene.tsx
+++ b/packages/client/src/components/Scene.tsx
@@ -5,6 +5,7 @@ import { Machine } from './Machine';
 
 interface SceneProps {
   state: TeamState;
+  className?: string;
 }
 
 // Layout positions for agent workstations (team mode — classic roles)
@@ -383,7 +384,7 @@ function AgentDetail({ agent, x, y, onClose, tasks }: { agent: AgentState; x: nu
   );
 }
 
-export function Scene({ state }: SceneProps) {
+export function Scene({ state, className }: SceneProps) {
   const mainAgents = state.agents.filter((a) => !a.isSubagent);
   const subagents = state.agents.filter((a) => a.isSubagent);
   // Solo mode: one main agent, possibly with subagents
@@ -395,7 +396,7 @@ export function Scene({ state }: SceneProps) {
 
   if (!state.name && state.agents.length === 0) {
     return (
-      <div className="scene-container no-team">
+      <div className={`scene-container no-team${className ? ` ${className}` : ''}`}>
         <h2>The Workshop in the Woods</h2>
         <p>Waiting for a session to start...<br />
         Launch Claude Code to begin.</p>
@@ -404,7 +405,7 @@ export function Scene({ state }: SceneProps) {
   }
 
   return (
-    <div className="scene-container">
+    <div className={`scene-container${className ? ` ${className}` : ''}`}>
       <svg
         viewBox="0 0 900 600"
         width="100%"

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -6,30 +6,35 @@ import { MessageLog } from './MessageLog';
 interface SidebarProps {
   state: TeamState;
   open: boolean;
+  className?: string;
+  forceTab?: 'tasks' | 'messages';
 }
 
-export function Sidebar({ state, open }: SidebarProps) {
+export function Sidebar({ state, open, className, forceTab }: SidebarProps) {
   const [activeTab, setActiveTab] = useState<'tasks' | 'messages'>('tasks');
+  const displayTab = forceTab || activeTab;
 
   return (
-    <div className={`sidebar ${open ? '' : 'sidebar-collapsed'}`}>
-      <div className="sidebar-tabs">
-        <button
-          className={`sidebar-tab ${activeTab === 'tasks' ? 'active' : ''}`}
-          onClick={() => setActiveTab('tasks')}
-        >
-          Tasks ({state.tasks.length})
-        </button>
-        <button
-          className={`sidebar-tab ${activeTab === 'messages' ? 'active' : ''}`}
-          onClick={() => setActiveTab('messages')}
-        >
-          Messages ({state.messages.length})
-        </button>
-      </div>
+    <div className={`sidebar ${open ? '' : 'sidebar-collapsed'}${className ? ` ${className}` : ''}`}>
+      {!forceTab && (
+        <div className="sidebar-tabs">
+          <button
+            className={`sidebar-tab ${displayTab === 'tasks' ? 'active' : ''}`}
+            onClick={() => setActiveTab('tasks')}
+          >
+            Tasks ({state.tasks.length})
+          </button>
+          <button
+            className={`sidebar-tab ${displayTab === 'messages' ? 'active' : ''}`}
+            onClick={() => setActiveTab('messages')}
+          >
+            Messages ({state.messages.length})
+          </button>
+        </div>
+      )}
 
       <div className="sidebar-content">
-        {activeTab === 'tasks' ? (
+        {displayTab === 'tasks' ? (
           <TaskBoard tasks={state.tasks} agents={state.agents} />
         ) : (
           <MessageLog messages={state.messages} />

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -790,3 +790,222 @@ html, body, #root {
   color: var(--color-text-dim);
   margin-left: auto;
 }
+
+/* ========================================
+   MOBILE TABS (visible at <= 480px)
+   ======================================== */
+
+.mobile-tabs {
+  display: none;
+}
+
+/* ========================================
+   RESPONSIVE: TABLET (<= 768px)
+   ======================================== */
+
+@media (max-width: 768px) {
+  html, body, #root {
+    overflow-y: auto;
+  }
+
+  .app-wrapper {
+    height: auto;
+    min-height: 100%;
+  }
+
+  /* Stack header content vertically */
+  .app-header {
+    flex-wrap: wrap;
+    padding: 6px 8px;
+    gap: 4px;
+  }
+
+  .header-left {
+    flex-wrap: wrap;
+    gap: 4px;
+    order: 1;
+  }
+
+  .header-stats {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+    padding-top: 4px;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .sidebar-toggle {
+    order: 2;
+  }
+
+  /* Stack scene and sidebar vertically */
+  .app-body {
+    flex-direction: column;
+  }
+
+  /* SVG container: maintain 3:2 aspect ratio */
+  .scene-container {
+    flex: none;
+    width: 100%;
+    aspect-ratio: 3 / 2;
+    max-height: 50vh;
+  }
+
+  .scene-container svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* Sidebar takes remaining space below the scene */
+  .sidebar {
+    width: 100%;
+    min-width: 100%;
+    border-left: none;
+    border-top: 2px solid var(--color-border);
+    max-height: 50vh;
+  }
+
+  .sidebar.sidebar-collapsed {
+    max-height: 0;
+    border-top: none;
+  }
+
+  /* Session picker dropdown: don't overflow viewport */
+  .session-picker-dropdown {
+    left: auto;
+    right: 0;
+    max-width: calc(100vw - 24px);
+  }
+}
+
+/* ========================================
+   RESPONSIVE: MOBILE (<= 480px)
+   ======================================== */
+
+@media (max-width: 480px) {
+  /* Show mobile tabs, hide the sidebar toggle button */
+  .mobile-tabs {
+    display: flex;
+    width: 100%;
+    border-bottom: 2px solid var(--color-border);
+    background: var(--color-panel-bg);
+    flex-shrink: 0;
+  }
+
+  .mobile-tab {
+    flex: 1;
+    padding: 8px 4px;
+    text-align: center;
+    cursor: pointer;
+    background: transparent;
+    color: var(--color-text-dim);
+    border: none;
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    transition: color 0.2s, background 0.2s;
+  }
+
+  .mobile-tab:hover {
+    color: var(--color-text);
+  }
+
+  .mobile-tab.active {
+    color: var(--color-gold);
+    background: rgba(255, 215, 0, 0.1);
+    border-bottom: 2px solid var(--color-gold);
+  }
+
+  .sidebar-toggle {
+    display: none;
+  }
+
+  /* Header: more compact */
+  .app-header {
+    padding: 4px 8px;
+    min-height: 36px;
+  }
+
+  .header-team-name {
+    font-size: 12px;
+    max-width: 120px;
+  }
+
+  .header-stats {
+    gap: 6px;
+    font-size: 10px;
+  }
+
+  .connection-dot-label {
+    display: none;
+  }
+
+  /* Hide less important badges on small screens */
+  .header-left .badge-branch {
+    display: none;
+  }
+
+  /* App body: only show one panel at a time */
+  .app-body {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .scene-container {
+    max-height: none;
+    aspect-ratio: 3 / 2;
+  }
+
+  .scene-container.mobile-hidden {
+    display: none;
+  }
+
+  .sidebar {
+    max-height: none;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .sidebar.mobile-hidden {
+    display: none;
+  }
+
+  /* On mobile, sidebar is always "open" (visibility controlled by tabs) */
+  .sidebar.sidebar-collapsed {
+    width: 100%;
+    min-width: 100%;
+    border-top: none;
+    opacity: 1;
+    overflow: hidden;
+  }
+
+  /* Session picker dropdown */
+  .session-picker-dropdown {
+    position: fixed;
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    max-width: 100vw;
+    border-radius: 12px 12px 0 0;
+    max-height: 60vh;
+    overflow-y: auto;
+  }
+
+  .session-picker-trigger {
+    font-size: 11px;
+    padding: 3px 8px;
+  }
+
+  /* Larger touch targets for task cards */
+  .task-card {
+    padding: 12px;
+  }
+
+  .sidebar-tab {
+    padding: 8px 4px;
+    font-size: 11px;
+  }
+}


### PR DESCRIPTION
## Summary
- **Tablet (<=768px)**: Scene and sidebar stack vertically; header wraps stats to a second row; scene capped at 50vh with 3:2 aspect ratio maintained via CSS `aspect-ratio`
- **Mobile (<=480px)**: Three-tab navigation (Scene / Tasks / Messages) replaces the sidebar toggle; only one panel visible at a time; session picker opens as a bottom sheet; header condensed (connection label and branch badge hidden)
- Desktop layout is fully preserved with zero changes to the existing >768px experience

## Changes
- `packages/client/src/styles/index.css` — Media queries at 768px and 480px breakpoints with mobile tab styles
- `packages/client/src/App.tsx` — `useIsMobile` hook, mobile tab state, passes `className`/`forceTab` props to child components
- `packages/client/src/components/Scene.tsx` — Accepts optional `className` prop for mobile visibility toggling
- `packages/client/src/components/Sidebar.tsx` — Accepts `className` and `forceTab` props; hides internal tab bar when parent controls the tab

## Test plan
- [ ] Verify desktop (1440px) layout unchanged
- [ ] Resize to 768px: scene + sidebar should stack vertically, header stats wrap
- [ ] Resize to 480px: mobile tabs appear, only one panel at a time
- [ ] Test session picker dropdown at mobile width (should not overflow)
- [ ] Verify SVG scene scales smoothly at all widths (agent names/bubbles readable)
- [ ] `npm run build` passes

Generated with [Claude Code](https://claude.com/claude-code)