### PR TITLE
Add comprehensive test coverage (135 new tests)

### DIFF
--- a/packages/server/src/__tests__/parser.test.ts
+++ b/packages/server/src/__tests__/parser.test.ts
@@ -11,6 +11,7 @@ import {
   parseSessionMetadata,
   cleanProjectName,
   readFirstLine,
+  extractRecordType,
 } from '../parser';
 
 const TMP = join(tmpdir(), 'avt-parser-test-' + Date.now());
@@ -295,5 +296,513 @@ describe('readFirstLine', () => {
   it('returns null for missing file', async () => {
     const line = await readFirstLine(join(TMP, 'does-not-exist.jsonl'));
     expect(line).toBeNull();
+  });
+});
+
+describe('extractRecordType', () => {
+  it('extracts type from valid JSON', () => {
+    expect(extractRecordType('{"type":"assistant","content":[]}')).toBe('assistant');
+  });
+
+  it('extracts user type', () => {
+    expect(extractRecordType('{"type":"user","content":"hello"}')).toBe('user');
+  });
+
+  it('extracts tool_result type', () => {
+    expect(extractRecordType('{"type":"tool_result"}')).toBe('tool_result');
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(extractRecordType('not json')).toBeNull();
+  });
+
+  it('returns null when type is not a string', () => {
+    expect(extractRecordType('{"type":42}')).toBeNull();
+  });
+
+  it('returns null when type is missing', () => {
+    expect(extractRecordType('{"content":"hello"}')).toBeNull();
+  });
+});
+
+describe('parseTeamConfig edge cases', () => {
+  it('returns null when members is not an array', async () => {
+    const configPath = join(TMP, 'bad-members.json');
+    await writeFile(configPath, JSON.stringify({ members: 'not-array' }));
+    const result = await parseTeamConfig(configPath);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty object', async () => {
+    const configPath = join(TMP, 'empty-obj.json');
+    await writeFile(configPath, JSON.stringify({}));
+    const result = await parseTeamConfig(configPath);
+    expect(result).toBeNull();
+  });
+});
+
+describe('parseTaskFile edge cases', () => {
+  it('returns null for empty file content', async () => {
+    const taskPath = join(TMP, 'task-empty-content.json');
+    await writeFile(taskPath, '   \n  ');
+    const result = await parseTaskFile(taskPath);
+    expect(result).toBeNull();
+  });
+
+  it('normalizes "deleted" status to "completed"', async () => {
+    const taskPath = join(TMP, 'task-deleted.json');
+    await writeFile(taskPath, JSON.stringify({
+      id: '99',
+      subject: 'Deleted task',
+      status: 'deleted',
+    }));
+    const task = await parseTaskFile(taskPath);
+    expect(task).not.toBeNull();
+    expect(task!.status).toBe('completed');
+  });
+
+  it('normalizes unknown status to "pending"', async () => {
+    const taskPath = join(TMP, 'task-unknown-status.json');
+    await writeFile(taskPath, JSON.stringify({
+      id: '100',
+      subject: 'Unknown status',
+      status: 'some_weird_status',
+    }));
+    const task = await parseTaskFile(taskPath);
+    expect(task!.status).toBe('pending');
+  });
+
+  it('uses filename as fallback ID when id field is missing', async () => {
+    const taskPath = join(TMP, 'task-55.json');
+    await writeFile(taskPath, JSON.stringify({ subject: 'No ID' }));
+    const task = await parseTaskFile(taskPath);
+    expect(task!.id).toBe('task-55');
+  });
+
+  it('handles JSON array by using defaults (typeof array is "object")', async () => {
+    const taskPath = join(TMP, 'task-array.json');
+    await writeFile(taskPath, '[1, 2, 3]');
+    const task = await parseTaskFile(taskPath);
+    // Arrays pass the typeof check, so they get treated as objects with missing fields
+    expect(task).not.toBeNull();
+    expect(task!.subject).toBe('Untitled');
+    expect(task!.status).toBe('pending');
+  });
+});
+
+describe('parseTranscriptLine edge cases', () => {
+  it('returns null for JSON array', () => {
+    expect(parseTranscriptLine('[1,2,3]')).toBeNull();
+  });
+
+  it('returns null for null JSON', () => {
+    expect(parseTranscriptLine('null')).toBeNull();
+  });
+
+  it('detects compact_boundary event', () => {
+    const line = JSON.stringify({
+      type: 'system',
+      subtype: 'compact_boundary',
+      compactMetadata: { preTokens: 167000 },
+    });
+    const result = parseTranscriptLine(line);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('compact');
+  });
+
+  it('detects microcompact_boundary event', () => {
+    const line = JSON.stringify({
+      type: 'system',
+      subtype: 'microcompact_boundary',
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('compact');
+  });
+
+  it('detects thinking block in assistant message', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [{ type: 'thinking', thinking: 'Let me think about this...' }],
+      },
+    });
+    const result = parseTranscriptLine(line);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('thinking');
+    expect(result!.toolName).toBe('Thinking...');
+  });
+
+  it('detects text block in assistant message as "Responding"', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'Here is my response...' }],
+      },
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('thinking');
+    expect(result!.toolName).toBe('Responding...');
+  });
+
+  it('detects bash_progress as progress type', () => {
+    const line = JSON.stringify({
+      type: 'progress',
+      data: { type: 'bash_progress', output: 'building...' },
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('progress');
+    expect(result!.toolName).toBe('Running command...');
+  });
+
+  it('detects agent_progress as progress type', () => {
+    const line = JSON.stringify({
+      type: 'progress',
+      data: { type: 'agent_progress' },
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('progress');
+    expect(result!.toolName).toBe('Agent working...');
+  });
+
+  it('detects generic progress without specific type', () => {
+    const line = JSON.stringify({
+      type: 'progress',
+      data: { type: 'hook_progress' },
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('progress');
+    expect(result!.toolName).toBeUndefined();
+  });
+
+  it('detects tool_output as agent_activity', () => {
+    const line = JSON.stringify({ type: 'tool_output', content: 'output' });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('agent_activity');
+  });
+
+  it('extracts agentName from agent_name field', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      agent_name: 'researcher',
+      content: [{ type: 'tool_use', name: 'Read', id: 'tu1', input: { file_path: '/f.ts' } }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.agentName).toBe('researcher');
+  });
+
+  it('extracts agentName from metadata.agentName', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      metadata: { agentName: 'tester' },
+      content: [{ type: 'tool_use', name: 'Bash', id: 'tu2', input: { command: 'npm test' } }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.agentName).toBe('tester');
+  });
+
+  it('extracts agentName from metadata.agent_name', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      metadata: { agent_name: 'planner' },
+      content: [{ type: 'tool_use', name: 'Write', id: 'tu3', input: { file_path: '/x.ts' } }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.agentName).toBe('planner');
+  });
+
+  it('detects tool_use in top-level format (format 2)', () => {
+    const line = JSON.stringify({
+      type: 'tool_use',
+      name: 'Edit',
+      id: 'tu-top',
+      input: { file_path: '/src/main.ts' },
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('tool_call');
+    expect(result!.toolName).toBe('Editing main.ts');
+  });
+
+  it('detects tool_use in nested message wrapper (format 3)', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'tool_use', name: 'Grep', id: 'tu-nested', input: { pattern: 'import' } },
+        ],
+      },
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('tool_call');
+    expect(result!.toolName).toBe('Searching: import');
+  });
+
+  it('marks AskUserQuestion as isUserPrompt', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{ type: 'tool_use', name: 'AskUserQuestion', id: 'tu4', input: {} }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.isUserPrompt).toBe(true);
+  });
+
+  it('marks EnterPlanMode as isUserPrompt', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{ type: 'tool_use', name: 'EnterPlanMode', id: 'tu5', input: {} }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.isUserPrompt).toBe(true);
+  });
+
+  it('marks ExitPlanMode as isUserPrompt', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{ type: 'tool_use', name: 'ExitPlanMode', id: 'tu6', input: {} }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.isUserPrompt).toBe(true);
+  });
+
+  it('does not mark regular tools as isUserPrompt', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{ type: 'tool_use', name: 'Read', id: 'tu7', input: { file_path: '/x.ts' } }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.isUserPrompt).toBe(false);
+  });
+
+  it('does not extract SendMessage without agentName', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        id: 'tu8',
+        name: 'SendMessage',
+        input: {
+          type: 'message',
+          recipient: 'lead',
+          content: 'hello',
+          summary: 'test',
+        },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    // Without agentName, parseSendMessageInput returns null, falls through to tool_call
+    expect(result!.type).toBe('tool_call');
+  });
+
+  it('handles SendMessage broadcast with recipient defaulting to "all"', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      agentName: 'lead',
+      content: [{
+        type: 'tool_use',
+        id: 'tu9',
+        name: 'SendMessage',
+        input: {
+          type: 'broadcast',
+          content: 'Attention everyone',
+          summary: 'Broadcast msg',
+        },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.type).toBe('message');
+    expect(result!.message!.to).toBe('all');
+  });
+});
+
+describe('parseTranscriptLine describeToolAction (parser version)', () => {
+  it('describes Bash with description', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'Bash',
+        input: { command: 'npm test', description: 'Run unit tests' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('Run unit tests');
+  });
+
+  it('describes Bash with command when no description', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'Bash',
+        input: { command: 'git status && git diff' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('Running: git status');
+  });
+
+  it('describes Bash with no input as "Running command"', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'Bash',
+        input: {},
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('Running command');
+  });
+
+  it('describes Glob with pattern', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'Glob',
+        input: { pattern: '**/*.tsx' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('Searching: **/*.tsx');
+  });
+
+  it('describes Task spawning', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'Task',
+        input: { description: 'Research API patterns' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('Spawning: Research API patterns');
+  });
+
+  it('describes TaskCreate with subject', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'TaskCreate',
+        input: { subject: 'Add auth' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('Creating task: Add auth');
+  });
+
+  it('describes TaskUpdate with status', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'TaskUpdate',
+        input: { status: 'completed' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toContain('completed');
+  });
+
+  it('describes WebSearch with query', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'WebSearch',
+        input: { query: 'react hooks tutorial' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('Searching: react hooks tutorial');
+  });
+
+  it('describes WebFetch', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'WebFetch',
+        input: { url: 'https://example.com' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('Fetching web page');
+  });
+
+  it('falls back to tool name for unknown tools', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      content: [{
+        type: 'tool_use',
+        name: 'CustomTool',
+        input: { foo: 'bar' },
+      }],
+    });
+    const result = parseTranscriptLine(line);
+    expect(result!.toolName).toBe('CustomTool');
+  });
+});
+
+describe('parseSessionMetadata edge cases', () => {
+  it('derives projectName from slug when cwd is empty', () => {
+    const line = JSON.stringify({
+      sessionId: 'sess-1',
+      slug: '-Users-Danny-Source-cool-project',
+      cwd: '',
+      type: 'user',
+    });
+    const result = parseSessionMetadata(line);
+    expect(result!.projectName).toBe('cool-project');
+  });
+
+  it('returns null for JSON array input', () => {
+    expect(parseSessionMetadata('[1,2,3]')).toBeNull();
+  });
+
+  it('handles cwd with no segments gracefully', () => {
+    const line = JSON.stringify({
+      sessionId: 'sess-1',
+      cwd: '/',
+      type: 'user',
+    });
+    const result = parseSessionMetadata(line);
+    expect(result).not.toBeNull();
+    // Root "/" splits to empty segments, projectName should fallback
+    expect(result!.projectName).toBeDefined();
+  });
+
+  it('sets lastActivity to 0 (caller should override)', () => {
+    const line = JSON.stringify({
+      sessionId: 'sess-1',
+      cwd: '/tmp',
+      type: 'user',
+    });
+    const result = parseSessionMetadata(line);
+    expect(result!.lastActivity).toBe(0);
+  });
+});
+
+describe('inferRole edge cases', () => {
+  it('identifies scribe as planner', () => {
+    expect(inferRole('default', 'scribe')).toBe('planner');
+  });
+
+  it('identifies architect as researcher', () => {
+    expect(inferRole('Architect', 'bob')).toBe('researcher');
+  });
+
+  it('identifies explore keyword as researcher', () => {
+    expect(inferRole('', 'explorer-bot')).toBe('researcher');
+  });
+
+  it('identifies validat keyword as tester', () => {
+    expect(inferRole('Validator', 'check')).toBe('tester');
+  });
+
+  it('returns implementer for generic names', () => {
+    expect(inferRole('', 'bob')).toBe('implementer');
+    expect(inferRole('Worker', 'agent-42')).toBe('implementer');
   });
 });


### PR DESCRIPTION
## Summary
- Doubles test coverage from 135 to 270 tests across all server modules
- New tests cover previously untested paths: ring buffer behavior, session management edge cases, task ownership reassignment, message deduplication, concurrent WebSocket clients, parser format variants, and hook event edge cases
- All 270 tests pass

## Test plan
- [x] All existing 135 tests still pass
- [x] All 135 new tests pass
- [x] `npx vitest run --config packages/server/vitest.config.ts` — 270/270 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)