### PR TITLE
Polish hooks: subagent matching, debouncing, compaction recovery

### DIFF
--- a/packages/server/src/__tests__/state.test.ts
+++ b/packages/server/src/__tests__/state.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StateManager } from '../state';
 import type { SessionInfo, AgentState, WSMessage } from '@agent-viewer/shared';
 
@@ -320,17 +320,22 @@ describe('StateManager', () => {
     });
 
     it('updateAgentActivityById broadcasts update when agent is displayed', () => {
+      vi.useFakeTimers();
       sm.registerAgent(makeAgent('s1', 'agent-a'));
       sm.addSession(makeSession('s1', 'project-a'));
 
       messages = []; // clear setup messages
       sm.updateAgentActivityById('s1', 'working', 'Running tests');
 
+      // Working updates are debounced by 200ms
+      vi.advanceTimersByTime(200);
+
       const updates = messages.filter((m) => m.type === 'agent_update');
       expect(updates).toHaveLength(1);
       if (updates[0].type === 'agent_update') {
         expect(updates[0].data.status).toBe('working');
       }
+      vi.useRealTimers();
     });
 
     it('updateAgentActivityById does not broadcast when agent is not displayed', () => {


### PR DESCRIPTION
## Summary
- **FIFO subagent spawn matching**: SubagentStart events now match pending Task tool calls in FIFO order (oldest first) and consume entries, correctly handling simultaneous subagent spawns from the same session instead of always picking the most recent one.
- **Activity debouncing**: Added 200ms debounce to updateAgentActivityById for working status broadcasts, reducing UI flicker during rapid Read->Edit->Write tool sequences. Idle/done transitions still broadcast immediately.
- **Post-compaction recovery**: After PreCompact fires, a 30s timeout auto-clears the Compacting conversation action. PreToolUse/PostToolUse events cancel the timer immediately when the agent resumes working.
- **Subagent tool routing**: Verified and tested that subagent tool events use the subagent own session_id, so existing routing correctly isolates subagent activity from the parent agent.

## Test plan
- [x] All 135 original tests still pass
- [x] 10 new tests added covering all four improvements
- [x] FIFO spawn matching: tests for correct ordering, consumption, and cross-session isolation
- [x] Compaction recovery: tests for 30s timeout, cancellation by PreToolUse, cancellation by PostToolUse
- [x] Subagent routing: tests for tool event isolation from parent
- [x] Debouncing: tests for broadcast coalescing and immediate idle/done delivery

Generated with [Claude Code](https://claude.com/claude-code)