### PR TITLE
Fix stale agents persisting in UI and remove redundant Done bubble

### DIFF
--- a/packages/client/src/components/Scene.tsx
+++ b/packages/client/src/components/Scene.tsx
@@ -200,9 +200,12 @@ function ActionBubble({ agent, x, y }: { agent: AgentState; x: number; y: number
 
   const isWorking = agent.status === 'working';
   const isDone = agent.status === 'done';
-  const text = agent.currentAction || (isWorking ? 'Working...' : (isDone ? 'Done' : ''));
+  // Don't show "Done" text — the green checkmark in AgentCharacter is sufficient
+  const text = agent.currentAction || (isWorking ? 'Working...' : '');
   // Always show something for subagents (their name describes what they're doing)
   if (!text && !isWorking && !agent.isSubagent) return null;
+  // Skip bubble entirely for done agents with no specific action
+  if (isDone && !agent.currentAction) return null;
   // For idle subagents with no action, show their name as context
   const displayText = text || (agent.isSubagent ? agent.name : '');
 
@@ -603,7 +606,7 @@ export function Scene({ state, className }: SceneProps) {
           if (!agent.gitBranch || agent.isSubagent) return null;
           const lane = branchLanes.get(agent.gitBranch);
           if (!lane) return null;
-          const pos = teamPositions?.get(agent.id) || getStationPos(agent, i, isSoloMode, 0, 0);
+          const pos = allPositions.get(agent.id) || { x: 450, y: 300 };
           // Tether from platform bottom (agent y + 28) to lane midpoint
           const tetherTop = pos.y + 28;
           const tetherBottom = lane.y + 9;

--- a/packages/server/src/hooks.ts
+++ b/packages/server/src/hooks.ts
@@ -636,10 +636,11 @@ export function createHookHandler(stateManager: StateManager) {
     console.log(`[hooks] SubagentStop: ${agentId} parent=${sessionId.slice(0, 8)}`);
 
     // Only schedule removal for subagents (not team members)
+    // Brief delay so user can see the done checkmark before removal
     if (!agent?.teamName) {
       setTimeout(() => {
         stateManager.removeAgent(agentId);
-      }, 120_000);
+      }, 15_000);
     }
   }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -97,9 +97,11 @@ wss.on('connection', (ws: WebSocket) => {
       if (!clientSessionId) {
         ws.send(JSON.stringify({ type: 'full_state', data: getClientState(ws) }));
       }
-    } else if (msg.type === 'agent_update' || msg.type === 'agent_added' || msg.type === 'agent_removed') {
+    } else if (msg.type === 'agent_removed') {
+      // Removal events always forwarded — agent is already gone from state
+      ws.send(JSON.stringify(msg));
+    } else if (msg.type === 'agent_update' || msg.type === 'agent_added') {
       // Agent events: only forward if the agent belongs to this client's selected session
-      // Re-derive the full state to check — the agent's presence in the filtered view is authoritative
       const filteredState = getClientState(ws);
       const agentInView = filteredState.agents.some((a) => a.id === msg.data.id);
       if (agentInView) {


### PR DESCRIPTION
## Summary

- **Stale agent fix**: `agent_removed` WebSocket messages were never reaching clients because `index.ts` filtered them — the agent was already gone from `state.agents` before the broadcast. Now `agent_removed` is always forwarded to all clients.
- **Faster cleanup**: Subagent removal delay reduced from 2 minutes to 15 seconds. Users see the green done checkmark briefly, then the agent is cleaned up.
- **Remove Done bubble**: `ActionBubble` no longer shows "Done" text for finished agents — the green checkmark in `AgentCharacter` is sufficient.
- **Merge fix**: Branch tether line was referencing old `teamPositions`/`getStationPos` names from pre-PR#16 code.

## Test plan

- [x] TypeScript compiles clean
- [x] All 312 tests pass
- [ ] Manual: stop a subagent → verify it shows checkmark briefly then disappears (no page refresh needed)
- [ ] Manual: verify done agents no longer show "Done" text bubble above them

🤖 Generated with [Claude Code](https://claude.com/claude-code)