### PR TITLE
🛡️ Sentinel: Add security headers to server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-14 - Trusting Hook Inputs for Shell Execution
+**Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
+**Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
+**Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,6 +10,16 @@ const PORT = parseInt(process.env.PORT || '3001', 10);
 const app = express();
 const server = createServer(app);
 
+// Security headers
+app.disable('x-powered-by');
+app.use((_req, res, next) => {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+  res.setHeader('Referrer-Policy', 'no-referrer');
+  next();
+});
+
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: Date.now() });


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Add security headers

Added standard security headers to the Express server to improve security posture.
- `X-Content-Type-Options: nosniff`: Prevents browsers from interpreting files as a different MIME type than what is specified in the Content-Type header.
- `X-Frame-Options: DENY`: Prevents the site from being embedded in an iframe, protecting against clickjacking.
- `Strict-Transport-Security`: Enforces the use of HTTPS (HSTS).
- `Referrer-Policy`: Controls how much referrer information is sent with requests.
- Disabled `X-Powered-By`: Removes the header that identifies the server as running Express, reducing information leakage.

Verified by inspecting headers with `curl` and running existing tests.

---
*PR created automatically by Jules for task [8253279878528294000](https://jules.google.com/task/8253279878528294000) started by @goggledefogger*