### PR TITLE
🧹 remove unused readFirstLine helper function

### DIFF
--- a/packages/server/src/__tests__/parser.test.ts
+++ b/packages/server/src/__tests__/parser.test.ts
@@ -10,7 +10,6 @@ import {
   parseTranscriptLine,
   parseSessionMetadata,
   cleanProjectName,
-  readFirstLine,
   extractRecordType,
   detectGitWorktree,
 } from '../parser';
@@ -276,27 +275,6 @@ describe('parseSessionMetadata', () => {
     });
     const result = parseSessionMetadata(line);
     expect(result!.projectName).toBe('cool-app');
-  });
-});
-
-describe('readFirstLine', () => {
-  it('reads the first line of a JSONL file', async () => {
-    const filePath = join(TMP, 'test.jsonl');
-    await writeFile(filePath, '{"sessionId":"s1","type":"user"}\n{"sessionId":"s1","type":"assistant"}\n');
-    const line = await readFirstLine(filePath);
-    expect(line).toBe('{"sessionId":"s1","type":"user"}');
-  });
-
-  it('returns null for empty file', async () => {
-    const filePath = join(TMP, 'empty.jsonl');
-    await writeFile(filePath, '');
-    const line = await readFirstLine(filePath);
-    expect(line).toBeNull();
-  });
-
-  it('returns null for missing file', async () => {
-    const line = await readFirstLine(join(TMP, 'does-not-exist.jsonl'));
-    expect(line).toBeNull();
   });
 });
 

--- a/packages/server/src/parser.ts
+++ b/packages/server/src/parser.ts
@@ -449,37 +449,6 @@ export function extractRecordType(line: string): string | null {
 }
 
 /**
- * Read the first line of a file.
- */
-export async function readFirstLine(filePath: string): Promise<string | null> {
-  try {
-    const stats = await stat(filePath);
-    if (stats.size === 0) return null;
-
-    return new Promise((resolve) => {
-      let buffer = '';
-      const stream = createReadStream(filePath, { encoding: 'utf-8', start: 0 });
-      stream.on('data', (chunk: string) => {
-        buffer += chunk;
-        const newlineIdx = buffer.indexOf('\n');
-        if (newlineIdx !== -1) {
-          stream.destroy();
-          resolve(buffer.slice(0, newlineIdx));
-        }
-      });
-      stream.on('end', () => {
-        resolve(buffer.trim() || null);
-      });
-      stream.on('error', () => {
-        resolve(null);
-      });
-    });
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Detect if a directory is inside a git worktree.
  * Returns { gitBranch, gitWorktree } if it is, or null values if not.
  */


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of an unused helper function `readFirstLine` in the server package.
💡 **Why:** Removing dead code improves maintainability and reduces the cognitive load for developers reading the codebase.
✅ **Verification:** Verified the change by running the remaining unit tests in `packages/server/src/__tests__/parser.test.ts` using `bun test`, all of which passed (86/86). Also confirmed no other usages exist with grep.
✨ **Result:** The codebase is now cleaner and free of the unused `readFirstLine` function and its tests.

---
*PR created automatically by Jules for task [16105969978516315814](https://jules.google.com/task/16105969978516315814) started by @goggledefogger*