### PR TITLE
🔒 [security fix] Restrict network binding to 127.0.0.1

### DIFF
--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
   });
 
   await new Promise<void>((resolve) => {
-    server.listen(PORT, resolve);
+    server.listen(PORT, '127.0.0.1', resolve);
   });
 });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -157,7 +157,7 @@ process.on('SIGINT', () => {
   process.exit(0);
 });
 
-server.listen(PORT, () => {
-  console.log(`[server] listening on http://localhost:${PORT}`);
-  console.log(`[server] WebSocket on ws://localhost:${PORT}/ws`);
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[server] listening on http://127.0.0.1:${PORT}`);
+  console.log(`[server] WebSocket on ws://127.0.0.1:${PORT}/ws`);
 });


### PR DESCRIPTION
The server was previously listening on all interfaces because `server.listen(PORT)` was called without a host argument. This allowed any device on the network to access the local tool's server. By specifying `'127.0.0.1'`, the server is now restricted to the local machine only. I have also updated the console logs and the test suite to reflect this change.

---
*PR created automatically by Jules for task [12653403336836195086](https://jules.google.com/task/12653403336836195086) started by @goggledefogger*