### PR TITLE
🧪 [testing improvement] Unit test applyMessage logic in useWebSocket.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "concurrently -n server,client -c blue,green \"npm run dev -w packages/server\" \"npm run dev -w packages/client\"",
     "build": "npm run build -w packages/shared && npm run build -w packages/server && npm run build -w packages/client",
     "test": "npm run test:unit && npm run test:build",
-    "test:unit": "npx vitest run --config packages/server/vitest.config.ts",
+    "test:unit": "npx vitest run --config packages/server/vitest.config.ts && npx vitest run --config packages/client/vitest.config.ts",
     "test:build": "npm run build -w packages/client",
     "test:e2e": "npx playwright test",
     "test:all": "npm run test:unit && npm run test:build && npm run test:e2e",

--- a/packages/client/src/hooks/__tests__/applyMessage.test.ts
+++ b/packages/client/src/hooks/__tests__/applyMessage.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { applyMessage } from '../useWebSocket';
+import type { TeamState, AgentState, TaskState, MessageState, WSMessage } from '@agent-viewer/shared';
+
+const initialTeamState: TeamState = {
+  name: 'Test Team',
+  agents: [],
+  tasks: [],
+  messages: [],
+};
+
+describe('applyMessage', () => {
+  it('should handle full_state', () => {
+    const newState: TeamState = {
+      name: 'New Team',
+      agents: [{ id: '1', name: 'Agent 1', role: 'lead', status: 'idle', tasksCompleted: 0 }],
+      tasks: [],
+      messages: [],
+    };
+    const message: WSMessage = { type: 'full_state', data: newState };
+
+    const result = applyMessage(initialTeamState, message);
+    expect(result).toEqual(newState);
+  });
+
+  it('should handle agent_update', () => {
+    const stateWithAgent: TeamState = {
+      ...initialTeamState,
+      agents: [{ id: '1', name: 'Agent 1', role: 'lead', status: 'idle', tasksCompleted: 0 }],
+    };
+    const updatedAgent: AgentState = { id: '1', name: 'Agent 1 Updated', role: 'lead', status: 'working', tasksCompleted: 1 };
+    const message: WSMessage = { type: 'agent_update', data: updatedAgent };
+
+    const result = applyMessage(stateWithAgent, message);
+    expect(result.agents[0]).toEqual(updatedAgent);
+    expect(result.agents.length).toBe(1);
+  });
+
+  it('should not update any agent if ID does not match in agent_update', () => {
+    const stateWithAgent: TeamState = {
+      ...initialTeamState,
+      agents: [{ id: '1', name: 'Agent 1', role: 'lead', status: 'idle', tasksCompleted: 0 }],
+    };
+    const updatedAgent: AgentState = { id: '2', name: 'Agent 2', role: 'tester', status: 'working', tasksCompleted: 1 };
+    const message: WSMessage = { type: 'agent_update', data: updatedAgent };
+
+    const result = applyMessage(stateWithAgent, message);
+    expect(result.agents[0].id).toBe('1');
+    expect(result.agents.length).toBe(1);
+  });
+
+  it('should handle agent_added', () => {
+    const newAgent: AgentState = { id: '2', name: 'Agent 2', role: 'tester', status: 'idle', tasksCompleted: 0 };
+    const message: WSMessage = { type: 'agent_added', data: newAgent };
+
+    const result = applyMessage(initialTeamState, message);
+    expect(result.agents).toContainEqual(newAgent);
+    expect(result.agents.length).toBe(1);
+  });
+
+  it('should handle agent_removed', () => {
+    const stateWithAgents: TeamState = {
+      ...initialTeamState,
+      agents: [
+        { id: '1', name: 'Agent 1', role: 'lead', status: 'idle', tasksCompleted: 0 },
+        { id: '2', name: 'Agent 2', role: 'tester', status: 'idle', tasksCompleted: 0 },
+      ],
+    };
+    const message: WSMessage = { type: 'agent_removed', data: { id: '1' } };
+
+    const result = applyMessage(stateWithAgents, message);
+    expect(result.agents.length).toBe(1);
+    expect(result.agents[0].id).toBe('2');
+  });
+
+  it('should handle task_update for existing task', () => {
+    const stateWithTask: TeamState = {
+      ...initialTeamState,
+      tasks: [{ id: 't1', subject: 'Task 1', status: 'pending', blockedBy: [], blocks: [] }],
+    };
+    const updatedTask: TaskState = { id: 't1', subject: 'Task 1 Updated', status: 'in_progress', blockedBy: [], blocks: [] };
+    const message: WSMessage = { type: 'task_update', data: updatedTask };
+
+    const result = applyMessage(stateWithTask, message);
+    expect(result.tasks[0]).toEqual(updatedTask);
+    expect(result.tasks.length).toBe(1);
+  });
+
+  it('should handle task_update for new task', () => {
+    const newTask: TaskState = { id: 't2', subject: 'Task 2', status: 'pending', blockedBy: [], blocks: [] };
+    const message: WSMessage = { type: 'task_update', data: newTask };
+
+    const result = applyMessage(initialTeamState, message);
+    expect(result.tasks).toContainEqual(newTask);
+    expect(result.tasks.length).toBe(1);
+  });
+
+  it('should handle new_message', () => {
+    const newMessage: MessageState = { id: 'm1', from: 'A', to: 'B', content: 'Hello', timestamp: Date.now() };
+    const message: WSMessage = { type: 'new_message', data: newMessage };
+
+    const result = applyMessage(initialTeamState, message);
+    expect(result.messages).toContainEqual(newMessage);
+    expect(result.messages.length).toBe(1);
+  });
+
+  it('should return current state for unknown message type', () => {
+    // @ts-expect-error - testing default case with unknown type
+    const message: WSMessage = { type: 'unknown_type', data: {} };
+
+    const result = applyMessage(initialTeamState, message);
+    expect(result).toBe(initialTeamState);
+  });
+});

--- a/packages/client/src/hooks/useWebSocket.ts
+++ b/packages/client/src/hooks/useWebSocket.ts
@@ -102,7 +102,7 @@ export function useWebSocket(url: string): WebSocketState {
   return { team: state, sessions, connectionStatus, selectSession };
 }
 
-function applyMessage(state: TeamState, msg: WSMessage): TeamState {
+export function applyMessage(state: TeamState, msg: WSMessage): TeamState {
   switch (msg.type) {
     case 'full_state':
       return msg.data;

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    root: __dirname,
+    include: ['src/**/*.test.ts'],
+    testTimeout: 10000,
+  },
+});


### PR DESCRIPTION
The `applyMessage` function in `useWebSocket.ts` was a private, pure reducer-like function. This PR exports it and adds a dedicated unit test suite to verify its logic for all supported WebSocket message types (`full_state`, `agent_update`, `agent_added`, `agent_removed`, `task_update`, and `new_message`), as well as handling unknown message types.

Changes:
1.  **Exported `applyMessage`**: Modified `packages/client/src/hooks/useWebSocket.ts` to export the function.
2.  **Added Unit Tests**: Created `packages/client/src/hooks/__tests__/applyMessage.test.ts` with test cases for state transitions.
3.  **Configured Vitest for Client**: Added `packages/client/vitest.config.ts`.
4.  **Updated Root Test Script**: Modified `package.json` to run both server and client unit tests.

---
*PR created automatically by Jules for task [4205795976632943558](https://jules.google.com/task/4205795976632943558) started by @goggledefogger*