### PR TITLE
🔒 Fix Insecure Network Binding Exposing Viewer to Local Network

### DIFF
--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -39,7 +39,7 @@ beforeAll(async () => {
   });
 
   await new Promise<void>((resolve) => {
-    server.listen(PORT, resolve);
+    server.listen(PORT, '127.0.0.1', resolve);
   });
 });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -157,7 +157,7 @@ process.on('SIGINT', () => {
   process.exit(0);
 });
 
-server.listen(PORT, () => {
-  console.log(`[server] listening on http://localhost:${PORT}`);
-  console.log(`[server] WebSocket on ws://localhost:${PORT}/ws`);
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[server] listening on http://127.0.0.1:${PORT}`);
+  console.log(`[server] WebSocket on ws://127.0.0.1:${PORT}/ws`);
 });


### PR DESCRIPTION
### 🔒 What: The vulnerability fixed
The server was previously listening on all network interfaces (defaulting to 0.0.0.0), which exposed the viewer to any device on the same local network.

### ⚠️ Risk: The potential impact if left unfixed
An attacker on the same local network could potentially access the Agent Viewer Town dashboard, seeing sensitive information about Claude Code sessions, project paths, and agent activities.

### 🛡️ Solution: How the fix addresses the vulnerability
The server is now explicitly bound to the loopback interface (`127.0.0.1`), ensuring it only accepts connections from the local machine. This is the standard security practice for development tools intended for local use.


---
*PR created automatically by Jules for task [7565757640319710811](https://jules.google.com/task/7565757640319710811) started by @goggledefogger*