### PR TITLE
🛡️ Sentinel: [Security Enhancement] Add Content Security Policy to Client

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -3,6 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Content Security Policy:
+      - allow local scripts and styles
+      - allow WebSocket connections to:
+        * Vite HMR (ws://localhost:5173)
+        * API Server (ws://localhost:3001)
+      - allow HTTP connections to API Server (http://localhost:3001)
+      Note: Ports 3001 and 5173 are hardcoded defaults.
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws://localhost:5173 ws://localhost:3001 ws://127.0.0.1:3001 http://localhost:3001 http://127.0.0.1:3001;" />
     <title>Agent Viewer Town</title>
   </head>
   <body>


### PR DESCRIPTION
This PR enhances the security of the client application by adding a Content Security Policy (CSP) meta tag.

**Changes:**
- Added `<meta http-equiv="Content-Security-Policy" ...>` to `packages/client/index.html`.

**Security Improvements:**
- Restricts script and style execution to 'self' and inline (necessary for Vite dev mode).
- Restricts image sources to 'self' and data URIs.
- Explicitly allows WebSocket and HTTP connections only to the expected API and Vite HMR ports (3001 and 5173).

**Limitations:**
- The CSP hardcodes `localhost:3001` and `localhost:5173` which are the default ports for the API server and Vite dev server respectively. This mirrors the existing hardcoded configuration in `vite.config.ts` and `App.tsx`.
- 'unsafe-inline' is enabled for scripts and styles to support Vite's development mode and React's inline styles.

**Verification:**
- Verified `index.html` syntax.
- Verified server tests pass (`bun test packages/server`).
- Client build was skipped due to environment restrictions but the change is a standard HTML meta tag addition.

---
*PR created automatically by Jules for task [6251339921554486091](https://jules.google.com/task/6251339921554486091) started by @goggledefogger*