### PR TITLE
🛡️ Sentinel: [HIGH] Fix input validation on hook endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2026-02-15 - Hook Endpoint Input Validation
+**Vulnerability:** The `/api/hook` endpoint accepted relative `cwd` paths, which could lead to ambiguous or incorrect git operations, and unlimited `session_id` lengths, potentially causing memory exhaustion.
+**Learning:** Even internal tools need robust input validation. Relative paths in `cwd` arguments for `execFile` or `spawn` can have unintended consequences if the server's working directory is not what the caller expects.
+**Prevention:** Always enforce absolute paths for `cwd` using `path.isAbsolute()` and sanitize/limit identifier strings.

--- a/packages/server/src/__tests__/security_validation.test.ts
+++ b/packages/server/src/__tests__/security_validation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import path from 'path';
+
+let serverProcess: ChildProcess;
+const PORT = 3097;
+
+beforeAll(async () => {
+  const serverDir = path.resolve(__dirname, '../../');
+
+  serverProcess = spawn('npx', ['tsx', 'src/index.ts'], {
+    cwd: serverDir,
+    env: { ...process.env, PORT: PORT.toString() },
+    stdio: 'pipe',
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onData = (data: Buffer) => {
+      const msg = data.toString();
+      if (msg.includes('listening on')) {
+        serverProcess.stdout?.off('data', onData);
+        resolve();
+      }
+    };
+    serverProcess.stdout?.on('data', onData);
+    serverProcess.stderr?.on('data', (data) => console.error('Server stderr:', data.toString()));
+    serverProcess.on('error', reject);
+    setTimeout(() => reject(new Error('Server start timeout')), 10000);
+  });
+});
+
+afterAll(() => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+});
+
+describe('Security: Additional Input Validation', () => {
+  it('rejects event with relative cwd path', async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/hook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: 'test-session-relative-cwd',
+        cwd: './relative/path'
+      }),
+    });
+    // Should be 400 after fix
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('absolute');
+  });
+
+  it('rejects event with overly long session_id', async () => {
+    const longId = 'a'.repeat(300);
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/hook`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: longId,
+      }),
+    });
+    // Should be 400 after fix
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('too long');
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { createServer } from 'http';
+import path from 'path';
 import { WebSocketServer, WebSocket } from 'ws';
 import { StateManager } from './state';
 import { startWatcher } from './watcher';
@@ -69,8 +70,17 @@ function validateHookEvent(event: any): string | null {
     return 'session_id must be a string';
   }
 
-  if (event.cwd !== undefined && typeof event.cwd !== 'string') {
-    return 'cwd must be a string';
+  if (event.session_id && event.session_id.length > 256) {
+    return 'session_id is too long (max 256 chars)';
+  }
+
+  if (event.cwd !== undefined) {
+    if (typeof event.cwd !== 'string') {
+      return 'cwd must be a string';
+    }
+    if (!path.isAbsolute(event.cwd)) {
+      return 'cwd must be an absolute path';
+    }
   }
 
   return null;


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix input validation on hook endpoint

**Vulnerability:**
The `/api/hook` endpoint accepted relative paths for `cwd`, which could resolve to unintended locations depending on the server's working directory. Additionally, `session_id` had no length limit, posing a potential denial-of-service risk via memory exhaustion.

**Fix:**
- Enforced `path.isAbsolute(cwd)` check in `validateHookEvent`.
- Added a maximum length check (256 chars) for `session_id`.
- Added automated tests in `packages/server/src/__tests__/security_validation.test.ts`.

**Verification:**
Run `npm run test:unit packages/server/src/__tests__/security_validation.test.ts` to confirm that invalid inputs are rejected with 400 Bad Request.
Run `npm run test:unit packages/server/src/__tests__/security.test.ts` to confirm existing functionality is preserved.

---
*PR created automatically by Jules for task [12630237334135519162](https://jules.google.com/task/12630237334135519162) started by @goggledefogger*