### PR TITLE
feat: character assignment, branch sidebar, tab isolation fixes

### DIFF
--- a/Launcher.applescript
+++ b/Launcher.applescript
@@ -1,5 +1,5 @@
 on run
-	do shell script "zsh -l -c 'cd /Users/Danny/Source/agent-viewer-town && npm run dev > /tmp/agent-viewer-dev.log 2>&1 & echo $! > /tmp/agent-viewer-dev.pid'"
+	do shell script "zsh -i -c 'source ~/.zshrc 2>/dev/null; cd /Users/Danny/Source/agent-viewer-town && npm run dev > /tmp/agent-viewer-dev.log 2>&1 & echo $! > /tmp/agent-viewer-dev.pid'"
 	delay 2
 	do shell script "open http://localhost:5173"
 end run

--- a/Launcher.applescript
+++ b/Launcher.applescript
@@ -1,0 +1,19 @@
+on run
+	do shell script "zsh -l -c 'cd /Users/Danny/Source/agent-viewer-town && npm run dev > /tmp/agent-viewer-dev.log 2>&1 & echo $! > /tmp/agent-viewer-dev.pid'"
+end run
+
+on quit
+	try
+		do shell script "kill $(cat /tmp/agent-viewer-dev.pid)"
+	end try
+	try
+		do shell script "pkill -f 'concurrently.*packages/server'"
+	end try
+	try
+		do shell script "pkill -f 'tsx watch src/index.ts'"
+	end try
+	try
+		do shell script "pkill -f 'vite'"
+	end try
+	continue quit
+end quit

--- a/Launcher.applescript
+++ b/Launcher.applescript
@@ -1,5 +1,7 @@
 on run
 	do shell script "zsh -l -c 'cd /Users/Danny/Source/agent-viewer-town && npm run dev > /tmp/agent-viewer-dev.log 2>&1 & echo $! > /tmp/agent-viewer-dev.pid'"
+	delay 2
+	do shell script "open http://localhost:5173"
 end run
 
 on quit

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ Then open **http://localhost:5173** in your browser.
 
 The viewer will automatically detect active Claude Code sessions from `~/.claude/`.
 
+### macOS Dock App
+
+If you are on a Mac, you can create a standalone app that lives in your Dock to easily start and stop the viewer in the background:
+
+```bash
+# Compile the AppleScript into a Mac App on your Desktop
+osacompile -o "$HOME/Desktop/Agent Viewer Servers.app" Launcher.applescript
+
+# Ensure the app stays open while running to allow quitting from the Dock
+defaults write "$HOME/Desktop/Agent Viewer Servers.app/Contents/Info.plist" OSAAppletStayOpen -bool YES
+```
+
+Once created, just open the app to start the servers in the background. Right-click the icon in your Dock and select "Quit" to stop them.
+
 ## How It Works
 
 ### Two Detection Systems

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -268,6 +268,8 @@ export default function App() {
           className={isMobile && mobileTab !== 'scene' ? 'mobile-hidden' : undefined}
           focusAgentId={focusAgentId}
           onFocusTask={handleFocusTask}
+          groupedSessions={groupedSessions}
+          onSelectSession={handleSelectSession}
         />
         <Sidebar
           state={state}

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -140,22 +140,17 @@ export default function App() {
           {showNavigation ? (
             <Breadcrumb
               segments={navigation.breadcrumbs}
-              onNavigate={navigation.zoomTo}
               onToggleDropdown={navigation.toggleOpen}
               waitingCount={navigation.waitingCount}
               isOpen={navigation.isOpen}
             >
               <NavigationTree
-                zoomLevel={navigation.zoomLevel}
                 visibleProjects={navigation.visibleProjects}
-                currentProject={navigation.currentProject}
-                currentBranch={navigation.currentBranch}
                 searchFilter={navigation.searchFilter}
                 hideIdle={navigation.hideIdle}
                 isOpen={navigation.isOpen}
                 activeSessionId={session?.sessionId}
                 onSelectSession={handleSelectSession}
-                onZoomTo={navigation.zoomTo}
                 onSearchChange={navigation.setSearchFilter}
                 onToggleHideIdle={navigation.toggleHideIdle}
                 onClose={navigation.close}

--- a/packages/client/src/components/AgentCharacter.tsx
+++ b/packages/client/src/components/AgentCharacter.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import type { AgentState } from '@agent-viewer/shared';
 import { resolveCharacter, getEvolutionStage } from '../svg/characters';
+import type { ProjectInfo } from '../svg/characters';
 import { STEAM_COLORS, SPARK_COLORS, CONFETTI_COLORS, getBranchColor } from '../constants/colors';
 export { getBranchColor } from '../constants/colors';
 
@@ -9,6 +10,7 @@ interface AgentCharacterProps {
   x: number;
   y: number;
   isNew?: boolean;
+  projectInfo?: ProjectInfo;
 }
 
 /** Steam puff particles that rise and fade when agent is working */
@@ -201,8 +203,8 @@ function CelebrationParticles({ active }: { active: boolean }) {
   );
 }
 
-export function AgentCharacter({ agent, x, y, isNew }: AgentCharacterProps) {
-  const { AnimalComponent: AnimalSvg, accentColor: color } = resolveCharacter(agent);
+export function AgentCharacter({ agent, x, y, isNew, projectInfo }: AgentCharacterProps) {
+  const { AnimalComponent: AnimalSvg, accentColor: color } = resolveCharacter(agent, projectInfo);
   const stage = agent.isSubagent ? 1 : getEvolutionStage(agent.tasksCompleted);
   const isWorking = agent.status === 'working';
   const isCompacting = isWorking && !!(agent.currentAction && agent.currentAction.includes('Compacting'));

--- a/packages/client/src/components/BranchSidebar.tsx
+++ b/packages/client/src/components/BranchSidebar.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect } from 'react';
+import type { BranchGroup } from '@agent-viewer/shared';
+import { getBranchColor } from '../constants/colors';
+
+interface BranchSidebarProps {
+  projectName: string;
+  projectBranches: BranchGroup[];
+  activeSessionId?: string;
+  onSelectSession: (sessionId: string) => void;
+  currentBranch?: string;
+}
+
+function isRecentlyActive(lastActivity: number, thresholdMs = 10_000): boolean {
+  return Date.now() - lastActivity < thresholdMs;
+}
+
+function ActivityDot({ lastActivity }: { lastActivity: number }) {
+  const [active, setActive] = useState(() => isRecentlyActive(lastActivity));
+
+  useEffect(() => {
+    setActive(isRecentlyActive(lastActivity));
+    const interval = setInterval(() => setActive(isRecentlyActive(lastActivity)), 2000);
+    return () => clearInterval(interval);
+  }, [lastActivity]);
+
+  if (!active) return null;
+  return <span className="branch-sidebar-activity-dot" title="Active" />;
+}
+
+export function BranchSidebar({
+  projectName,
+  projectBranches,
+  activeSessionId,
+  onSelectSession,
+  currentBranch,
+}: BranchSidebarProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (collapsed) {
+    return (
+      <button
+        className="branch-sidebar-toggle branch-sidebar-toggle--collapsed"
+        onClick={() => setCollapsed(false)}
+        title="Show branch sidebar"
+      >
+        <span className="branch-sidebar-toggle-icon">{'\u25B6'}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="branch-sidebar">
+      <div className="branch-sidebar-header">
+        <span className="branch-sidebar-title" title={projectName}>
+          {projectName}
+        </span>
+        <button
+          className="branch-sidebar-toggle"
+          onClick={() => setCollapsed(true)}
+          title="Hide branch sidebar"
+        >
+          {'\u25C0'}
+        </button>
+      </div>
+
+      <div className="branch-sidebar-list">
+        {projectBranches.map((bg) => {
+          const color = getBranchColor(bg.branch);
+          const isActiveBranch = bg.branch === currentBranch;
+          const hasSingleSession = bg.sessions.length === 1;
+
+          return (
+            <div key={bg.branch} className="branch-sidebar-branch">
+              {/* Branch header row */}
+              <div
+                className={`branch-sidebar-item${isActiveBranch ? ' branch-sidebar-item--active' : ''}`}
+                onClick={hasSingleSession ? () => onSelectSession(bg.sessions[0].sessionId) : undefined}
+                style={hasSingleSession ? { cursor: 'pointer' } : undefined}
+              >
+                <span className="branch-sidebar-color-dot" style={{ background: color }} />
+                <span className="branch-sidebar-branch-name" title={bg.branch}>
+                  {bg.branch}
+                </span>
+                <span className="branch-sidebar-badges">
+                  {bg.totalAgents > 0 && (
+                    <span className="branch-sidebar-agent-count">{bg.totalAgents}</span>
+                  )}
+                  <ActivityDot lastActivity={bg.lastActivity} />
+                  {bg.hasWaitingAgent && (
+                    <span className="branch-sidebar-waiting-dot" title="Waiting for input" />
+                  )}
+                </span>
+              </div>
+
+              {/* Session list (only if branch has multiple sessions) */}
+              {!hasSingleSession && bg.sessions.length > 0 && (
+                <div className="branch-sidebar-sessions">
+                  {bg.sessions.map((s) => {
+                    const isActiveSession = s.sessionId === activeSessionId;
+                    return (
+                      <div
+                        key={s.sessionId}
+                        className={`branch-sidebar-session${isActiveSession ? ' branch-sidebar-session--active' : ''}`}
+                        onClick={() => onSelectSession(s.sessionId)}
+                      >
+                        <span className="branch-sidebar-session-slug">{s.slug}</span>
+                        <span className="branch-sidebar-session-badges">
+                          <span className={`branch-sidebar-session-type ${s.isTeam ? 'type-team' : 'type-solo'}`}>
+                            {s.isTeam ? 'Team' : 'Solo'}
+                          </span>
+                          {s.agentCount > 0 && (
+                            <span className="branch-sidebar-agent-count">{s.agentCount}</span>
+                          )}
+                          {s.hasWaitingAgent && (
+                            <span className="branch-sidebar-waiting-dot" title="Waiting for input" />
+                          )}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/Breadcrumb.tsx
+++ b/packages/client/src/components/Breadcrumb.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from 'react';
-import type { BreadcrumbSegment, ZoomLevel } from '../hooks/useNavigation';
+import type { BreadcrumbSegment } from '../hooks/useNavigation';
 
 interface BreadcrumbProps {
   segments: BreadcrumbSegment[];
-  onNavigate: (level: ZoomLevel, projectKey?: string, branch?: string) => void;
   onToggleDropdown: () => void;
   waitingCount: number;
   isOpen: boolean;
@@ -12,7 +11,6 @@ interface BreadcrumbProps {
 
 export function Breadcrumb({
   segments,
-  onNavigate,
   onToggleDropdown,
   waitingCount,
   isOpen,
@@ -27,22 +25,9 @@ export function Breadcrumb({
         aria-haspopup="listbox"
       >
         <span className="nav-breadcrumb-segments">
-          {segments.map((seg, i) => (
-            <span key={`${seg.level}-${seg.label}`} className="nav-breadcrumb-segment-wrapper">
-              {i > 0 && <span className="nav-breadcrumb-sep"> &gt; </span>}
-              {seg.isCurrent ? (
-                <span className="nav-breadcrumb-current">{seg.label}</span>
-              ) : (
-                <button
-                  className="nav-breadcrumb-link"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onNavigate(seg.level, seg.projectKey, seg.branch);
-                  }}
-                >
-                  {seg.label}
-                </button>
-              )}
+          {segments.map((seg) => (
+            <span key={seg.label} className="nav-breadcrumb-segment-wrapper">
+              <span className="nav-breadcrumb-current">{seg.label}</span>
             </span>
           ))}
         </span>

--- a/packages/client/src/components/Scene.tsx
+++ b/packages/client/src/components/Scene.tsx
@@ -7,6 +7,7 @@ import { AgentDetail } from './AgentDetail';
 import { SceneBackground, SubagentTethers, BranchTethers } from './SceneBackground';
 import { BranchSidebar } from './BranchSidebar';
 import { computeAllPositions, computeBranchLanes, computeBranchZones } from './sceneLayout';
+import type { ProjectInfo } from '../svg/characters';
 
 interface SceneProps {
   state: TeamState;
@@ -110,6 +111,16 @@ export function Scene({ state, className, focusAgentId, onFocusTask, groupedSess
     if (!groupedSessions || !state.session?.projectPath) return null;
     return groupedSessions.projects.find(p => p.projectPath === state.session!.projectPath) || null;
   }, [groupedSessions, state.session]);
+
+  // Build project info for character resolution (solo agents get project-based animals)
+  const projectInfo: ProjectInfo | undefined = useMemo(() => {
+    if (!state.session) return undefined;
+    return {
+      projectPath: state.session.projectPath,
+      projectName: state.session.projectName,
+      gitBranch: state.session.gitBranch,
+    };
+  }, [state.session]);
 
   if (!state.name && state.agents.length === 0) {
     return (
@@ -235,7 +246,7 @@ export function Scene({ state, className, focusAgentId, onFocusTask, groupedSess
                   </g>
                 );
               })()}
-              <AgentCharacter agent={agent} x={pos.x} y={pos.y} />
+              <AgentCharacter agent={agent} x={pos.x} y={pos.y} projectInfo={projectInfo} />
               <ActionBubble agent={agent} x={pos.x} y={pos.y} />
             </g>
           );

--- a/packages/client/src/components/Scene.tsx
+++ b/packages/client/src/components/Scene.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo, useEffect } from 'react';
-import type { TeamState, AgentState } from '@agent-viewer/shared';
+import type { TeamState, AgentState, GroupedSessionsList } from '@agent-viewer/shared';
 import { AgentCharacter } from './AgentCharacter';
 import { Machine } from './Machine';
 import { ActionBubble } from './ActionBubble';
 import { AgentDetail } from './AgentDetail';
 import { SceneBackground, SubagentTethers, BranchTethers } from './SceneBackground';
+import { BranchSidebar } from './BranchSidebar';
 import { computeAllPositions, computeBranchLanes, computeBranchZones } from './sceneLayout';
 
 interface SceneProps {
@@ -12,6 +13,8 @@ interface SceneProps {
   className?: string;
   focusAgentId?: string | null;
   onFocusTask?: (taskId: string) => void;
+  groupedSessions?: GroupedSessionsList;
+  onSelectSession?: (sessionId: string) => void;
 }
 
 // --- Zoom & Pan Constants ---
@@ -22,7 +25,7 @@ const BASE_HEIGHT = 600;
 
 const clamp = (val: number, min: number, max: number) => Math.min(Math.max(val, min), max);
 
-export function Scene({ state, className, focusAgentId, onFocusTask }: SceneProps) {
+export function Scene({ state, className, focusAgentId, onFocusTask, groupedSessions, onSelectSession }: SceneProps) {
   const mainAgents = useMemo(() => state.agents.filter((a) => !a.isSubagent), [state.agents]);
   const subagents = useMemo(() => state.agents.filter((a) => a.isSubagent), [state.agents]);
   const isSoloMode = mainAgents.length <= 1;
@@ -102,6 +105,12 @@ export function Scene({ state, className, focusAgentId, onFocusTask }: SceneProp
   const branchLanes = useMemo(() => computeBranchLanes(state.agents), [state.agents]);
   const branchZones = useMemo(() => computeBranchZones(state.agents, allPositions), [state.agents, allPositions]);
 
+  // Find the current project's branches for the sidebar
+  const currentProject = useMemo(() => {
+    if (!groupedSessions || !state.session?.projectPath) return null;
+    return groupedSessions.projects.find(p => p.projectPath === state.session!.projectPath) || null;
+  }, [groupedSessions, state.session]);
+
   if (!state.name && state.agents.length === 0) {
     return (
       <div className={`scene-container no-team${className ? ` ${className}` : ''}`}>
@@ -114,6 +123,17 @@ export function Scene({ state, className, focusAgentId, onFocusTask }: SceneProp
 
   return (
     <div className={`scene-container${className ? ` ${className}` : ''}`} style={{ cursor: isDragging ? 'grabbing' : 'grab' }}>
+      {/* Branch sidebar overlay */}
+      {currentProject && currentProject.branches.length > 1 && onSelectSession && (
+        <BranchSidebar
+          projectName={currentProject.projectName}
+          projectBranches={currentProject.branches}
+          activeSessionId={state.session?.sessionId}
+          onSelectSession={onSelectSession}
+          currentBranch={state.session?.gitBranch}
+        />
+      )}
+
       {/* Zoom Controls Overlay */}
       <div className="scene-controls">
         <button onClick={(e) => zoomBy(0.2, e)} title="Zoom In">+</button>

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -307,7 +307,14 @@ html, body, #root {
   flex: 1;
   position: relative;
   overflow: hidden;
+  display: flex;
   /* Cursor style is now handled dynamically via inline style in Scene.tsx for grab/grabbing */
+}
+
+/* SVG fills remaining space after sidebar */
+.scene-container svg {
+  flex: 1;
+  min-width: 0;
 }
 
 /* Zoom Controls Overlay */
@@ -2066,22 +2073,17 @@ html, body, #root {
 }
 
 /* ========================================
-   BRANCH SIDEBAR (scene overlay)
+   BRANCH SIDEBAR (flex child of scene-container)
    ======================================== */
 
 .branch-sidebar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
   width: 180px;
+  flex-shrink: 0;
   background: rgba(15, 52, 96, 0.92);
   border-right: 1px solid var(--color-border);
-  z-index: 90;
   display: flex;
   flex-direction: column;
   font-family: 'Courier New', monospace;
-  backdrop-filter: blur(6px);
   overflow: hidden;
 }
 
@@ -2123,11 +2125,10 @@ html, body, #root {
 }
 
 .branch-sidebar-toggle--collapsed {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  z-index: 90;
+  flex-shrink: 0;
+  align-self: center;
+  margin-top: auto;
+  margin-bottom: auto;
   background: rgba(15, 52, 96, 0.85);
   border: 1px solid var(--color-border);
   border-left: none;
@@ -2137,7 +2138,6 @@ html, body, #root {
   padding: 8px 4px;
   font-size: 10px;
   line-height: 1;
-  backdrop-filter: blur(4px);
   transition: color 0.15s ease, background 0.15s ease;
 }
 

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -2058,4 +2058,253 @@ html, body, #root {
     padding: 8px 4px;
     font-size: 11px;
   }
+
+  .branch-sidebar,
+  .branch-sidebar-toggle--collapsed {
+    display: none !important;
+  }
+}
+
+/* ========================================
+   BRANCH SIDEBAR (scene overlay)
+   ======================================== */
+
+.branch-sidebar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 180px;
+  background: rgba(15, 52, 96, 0.92);
+  border-right: 1px solid var(--color-border);
+  z-index: 90;
+  display: flex;
+  flex-direction: column;
+  font-family: 'Courier New', monospace;
+  backdrop-filter: blur(6px);
+  overflow: hidden;
+}
+
+.branch-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-border);
+  min-height: 32px;
+}
+
+.branch-sidebar-title {
+  font-size: 10px;
+  font-weight: bold;
+  color: var(--color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.branch-sidebar-toggle {
+  background: none;
+  border: none;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 2px 4px;
+  line-height: 1;
+  border-radius: 2px;
+  transition: color 0.15s ease;
+}
+
+.branch-sidebar-toggle:hover {
+  color: var(--color-text);
+}
+
+.branch-sidebar-toggle--collapsed {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  z-index: 90;
+  background: rgba(15, 52, 96, 0.85);
+  border: 1px solid var(--color-border);
+  border-left: none;
+  border-radius: 0 4px 4px 0;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 8px 4px;
+  font-size: 10px;
+  line-height: 1;
+  backdrop-filter: blur(4px);
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.branch-sidebar-toggle--collapsed:hover {
+  color: var(--color-text);
+  background: rgba(15, 52, 96, 0.95);
+}
+
+.branch-sidebar-toggle-icon {
+  display: block;
+}
+
+.branch-sidebar-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.branch-sidebar-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.branch-sidebar-list::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 2px;
+}
+
+.branch-sidebar-branch {
+  margin-bottom: 2px;
+}
+
+.branch-sidebar-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  transition: background 0.15s ease;
+}
+
+.branch-sidebar-item[style*="cursor: pointer"]:hover {
+  background: rgba(65, 105, 225, 0.15);
+}
+
+.branch-sidebar-item--active {
+  background: rgba(65, 105, 225, 0.2);
+  border-left: 2px solid var(--color-blue);
+  padding-left: 8px;
+}
+
+.branch-sidebar-color-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.branch-sidebar-branch-name {
+  font-size: 11px;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.branch-sidebar-badges {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.branch-sidebar-agent-count {
+  font-size: 9px;
+  color: var(--color-text-dim);
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1px 4px;
+  border-radius: 3px;
+  line-height: 1.2;
+}
+
+.branch-sidebar-activity-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-green);
+  flex-shrink: 0;
+  animation: branch-sidebar-pulse 2s ease-in-out infinite;
+}
+
+@keyframes branch-sidebar-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.branch-sidebar-waiting-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #EAB308;
+  flex-shrink: 0;
+  animation: branch-sidebar-waiting-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes branch-sidebar-waiting-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* Session sub-entries under a branch */
+.branch-sidebar-sessions {
+  padding-left: 22px;
+}
+
+.branch-sidebar-session {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  padding: 3px 10px 3px 0;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.branch-sidebar-session:hover {
+  background: rgba(65, 105, 225, 0.12);
+}
+
+.branch-sidebar-session--active {
+  background: rgba(65, 105, 225, 0.18);
+}
+
+.branch-sidebar-session-slug {
+  font-size: 10px;
+  color: var(--color-text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.branch-sidebar-session--active .branch-sidebar-session-slug {
+  color: var(--color-text);
+}
+
+.branch-sidebar-session-badges {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.branch-sidebar-session-type {
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 1px 3px;
+  border-radius: 2px;
+  line-height: 1.2;
+}
+
+.branch-sidebar-session-type.type-solo {
+  color: var(--color-text-dim);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.branch-sidebar-session-type.type-team {
+  color: var(--color-gold);
+  background: rgba(255, 215, 0, 0.1);
 }

--- a/packages/client/src/svg/characters/index.ts
+++ b/packages/client/src/svg/characters/index.ts
@@ -1,3 +1,4 @@
 export { resolveCharacter, getEvolutionStage } from './registry';
+export type { ProjectInfo } from './registry';
 export type { CharacterResolution, AccessorySlot, AccessoryDef } from './types';
 export { Beaver, Bear, Fox, Owl, Rabbit, Squirrel, Chipmunk, Woodpecker, Mouse } from './animals';

--- a/packages/client/src/svg/characters/registry.ts
+++ b/packages/client/src/svg/characters/registry.ts
@@ -1,12 +1,20 @@
 /** Character registry — centralizes the mapping from agent role/subagentType
  *  to animal component and accent color.
  *
- *  Previously this logic was scattered across AgentCharacter.tsx (lines 24-30, 162-165). */
+ *  Solo agents (role=implementer) get a deterministic animal based on project path,
+ *  so different projects show different characters. Team roles and subagents
+ *  keep their fixed mappings. */
 
 import type { AgentState } from '@agent-viewer/shared';
 import { ROLE_COLORS } from '../../constants/colors';
 import type { CharacterResolution } from './types';
 import { Beaver, Owl, Fox, Bear, Rabbit, Squirrel, Chipmunk, Woodpecker, Mouse } from './animals';
+
+export interface ProjectInfo {
+  projectPath: string;
+  projectName: string;
+  gitBranch?: string;
+}
 
 const ANIMAL_COMPONENTS: Record<string, React.FC<{ stage: number }>> = {
   lead: Beaver,
@@ -31,7 +39,21 @@ const SUBAGENT_ANIMALS: Record<string, React.FC<{ stage: number }>> = {
 /** Default subagent color when type is unknown */
 const SUBAGENT_DEFAULT_COLOR = '#94a3b8';
 
-export function resolveCharacter(agent: AgentState): CharacterResolution {
+/** Stable pool of animals and colors for solo (implementer) agents */
+const SOLO_ANIMAL_POOL = [Fox, Bear, Beaver, Owl, Rabbit, Squirrel, Chipmunk, Woodpecker, Mouse];
+const SOLO_COLOR_POOL = ['#DC3545', '#28A745', '#FFD700', '#4169E1', '#F8F9FA', '#26C6DA', '#FFCA28', '#FF7043', '#94a3b8'];
+
+/** Simple deterministic hash — same string always produces the same number */
+export function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+export function resolveCharacter(agent: AgentState, projectInfo?: ProjectInfo): CharacterResolution {
   if (agent.isSubagent) {
     const subType = agent.subagentType || '';
     return {
@@ -39,6 +61,16 @@ export function resolveCharacter(agent: AgentState): CharacterResolution {
       accentColor: SUBAGENT_COLORS[subType] || SUBAGENT_DEFAULT_COLOR,
     };
   }
+
+  // Solo agents (implementer) get project-based character when projectInfo is available
+  if (agent.role === 'implementer' && projectInfo) {
+    const index = hashString(projectInfo.projectPath) % SOLO_ANIMAL_POOL.length;
+    return {
+      AnimalComponent: SOLO_ANIMAL_POOL[index],
+      accentColor: SOLO_COLOR_POOL[index],
+    };
+  }
+
   return {
     AnimalComponent: ANIMAL_COMPONENTS[agent.role] || Beaver,
     accentColor: ROLE_COLORS[agent.role] || '#FFD700',

--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -576,7 +576,9 @@ export class StateManager {
       : session.projectName;
     this.state.agents = this.getAgentsForSession(session);
     this.state.tasks = session.isTeam ? this.state.tasks : [];
-    this.broadcastFullState();
+    // Only broadcast sessions list update (navigation tree).
+    // Do NOT broadcast full_state — each client has their own selectedSessionId
+    // and gets per-client filtered state via getStateForSession().
     this.broadcastSessionsList();
   }
 


### PR DESCRIPTION
## Summary

- **Per-project character assignment**: Solo agents get deterministic animals based on project path hash (not always Fox). Team roles and subagents keep existing mappings.
- **In-scene branch sidebar**: New left-side panel showing all branches/worktrees for the current project with activity indicators, waiting badges, and click-to-switch. Responsive flex layout (not overlay).
- **Simplified navigation**: Navbar reduced to project-level selection only (branches handled by sidebar). Removed zoom levels, drill-down.
- **Tab isolation fixes**: Tabs no longer auto-switch projects. Fixed reconnection bug (re-sends session selection). Client rejects full_state for wrong session.
- **Notification isolation**: BroadcastChannel deduplication prevents double chimes across tabs. Title flash only counts same-session waiting.
- **Dynamic tab title**: Browser tab shows `projectName (branch) - Agent Viewer Town`.

## Test plan
- [x] All 510 tests pass (106 client + 404 server)
- [ ] Open two tabs, select different projects — verify they stay separate
- [ ] Trigger a notification — verify chime plays in only one tab
- [ ] Check branch sidebar shows/hides correctly, switches sessions on click
- [ ] Verify SVG resizes properly when sidebar opens/collapses
- [ ] Verify different projects show different animal characters

Generated with [Claude Code](https://claude.com/claude-code)