### PR TITLE
🛡️ Sentinel: Enforce strict input validation for hook events

### DIFF
--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { validateHookEvent } from '../validation';
+import path from 'path';
+
+describe('validateHookEvent', () => {
+  const validEvent = {
+    hook_event_name: 'PreToolUse',
+    session_id: 'valid-session_123.ABC',
+    cwd: path.resolve('/tmp/project'), // Ensures absolute path for the current OS
+  };
+
+  it('accepts a valid event', () => {
+    expect(validateHookEvent(validEvent)).toBeNull();
+  });
+
+  it('rejects missing event object', () => {
+    expect(validateHookEvent(null)).toBe('Event must be a JSON object');
+    expect(validateHookEvent(undefined)).toBe('Event must be a JSON object');
+    expect(validateHookEvent('string')).toBe('Event must be a JSON object');
+  });
+
+  it('rejects missing hook_event_name', () => {
+    expect(validateHookEvent({ ...validEvent, hook_event_name: undefined })).toBe('hook_event_name is required and must be a string');
+  });
+
+  it('rejects unknown hook_event_name', () => {
+    expect(validateHookEvent({ ...validEvent, hook_event_name: 'InvalidEvent' })).toContain('Unknown hook_event_name');
+  });
+
+  describe('session_id validation', () => {
+    it('rejects non-string session_id', () => {
+      expect(validateHookEvent({ ...validEvent, session_id: 123 })).toBe('session_id must be a string');
+    });
+
+    it('rejects session_id with invalid characters', () => {
+      expect(validateHookEvent({ ...validEvent, session_id: 'bad/id' })).toBe('session_id contains invalid characters');
+      expect(validateHookEvent({ ...validEvent, session_id: 'bad id' })).toBe('session_id contains invalid characters');
+      expect(validateHookEvent({ ...validEvent, session_id: 'bad$id' })).toBe('session_id contains invalid characters');
+    });
+
+    it('rejects session_id that is too long', () => {
+      const longId = 'a'.repeat(129);
+      expect(validateHookEvent({ ...validEvent, session_id: longId })).toBe('session_id is too long (max 128 chars)');
+    });
+
+    it('accepts session_id with allowed special chars', () => {
+      expect(validateHookEvent({ ...validEvent, session_id: 'valid.id-with_underscore' })).toBeNull();
+    });
+  });
+
+  describe('cwd validation', () => {
+    it('rejects non-string cwd', () => {
+      expect(validateHookEvent({ ...validEvent, cwd: 123 })).toBe('cwd must be a string');
+    });
+
+    it('rejects relative cwd', () => {
+      expect(validateHookEvent({ ...validEvent, cwd: 'relative/path' })).toBe('cwd must be an absolute path');
+      expect(validateHookEvent({ ...validEvent, cwd: './relative/path' })).toBe('cwd must be an absolute path');
+    });
+
+    it('rejects cwd with traversal characters', () => {
+      const traversalPath = path.resolve('/tmp/foo/../bar'); // This resolves to /tmp/bar, so it IS valid if resolved first.
+      // But the input string might contain '..' explicitly if not resolved by the client.
+      // We want to test the string check.
+      const rawTraversalPath = '/tmp/foo/../bar';
+      expect(validateHookEvent({ ...validEvent, cwd: rawTraversalPath })).toBe('cwd cannot contain traversal characters');
+    });
+
+    it('rejects cwd that is too long', () => {
+      const longPath = '/' + 'a'.repeat(1024);
+      expect(validateHookEvent({ ...validEvent, cwd: longPath })).toBe('cwd is too long (max 1024 chars)');
+    });
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { StateManager } from './state';
 import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
+import { validateHookEvent } from './validation';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -35,48 +36,6 @@ const hookHandler = createHookHandler(stateManager);
 app.get('/api/state', (_req, res) => {
   res.json(stateManager.getState());
 });
-
-// Allowed hook event names for validation
-const VALID_HOOK_EVENTS = new Set([
-  'PreToolUse',
-  'PostToolUse',
-  'PostToolUseFailure',
-  'PermissionRequest',
-  'SubagentStart',
-  'SubagentStop',
-  'PreCompact',
-  'Stop',
-  'SessionStart',
-  'SessionEnd',
-  'TeammateIdle',
-  'TaskCompleted',
-  'UserPromptSubmit',
-  'Notification',
-]);
-
-function validateHookEvent(event: any): string | null {
-  if (!event || typeof event !== 'object') {
-    return 'Event must be a JSON object';
-  }
-
-  if (typeof event.hook_event_name !== 'string') {
-    return 'hook_event_name is required and must be a string';
-  }
-
-  if (!VALID_HOOK_EVENTS.has(event.hook_event_name)) {
-    return `Unknown hook_event_name: ${event.hook_event_name}`;
-  }
-
-  if (event.session_id !== undefined && typeof event.session_id !== 'string') {
-    return 'session_id must be a string';
-  }
-
-  if (event.cwd !== undefined && typeof event.cwd !== 'string') {
-    return 'cwd must be a string';
-  }
-
-  return null;
-}
 
 // Hook event endpoint — receives events from Claude Code lifecycle hooks
 app.post('/api/hook', (req, res) => {

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -1,0 +1,74 @@
+import path from 'path';
+
+// Allowed hook event names for validation
+export const VALID_HOOK_EVENTS = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionRequest',
+  'SubagentStart',
+  'SubagentStop',
+  'PreCompact',
+  'Stop',
+  'SessionStart',
+  'SessionEnd',
+  'TeammateIdle',
+  'TaskCompleted',
+  'UserPromptSubmit',
+  'Notification',
+]);
+
+/**
+ * Validates a hook event payload.
+ * Returns an error message string if invalid, or null if valid.
+ */
+export function validateHookEvent(event: any): string | null {
+  if (!event || typeof event !== 'object') {
+    return 'Event must be a JSON object';
+  }
+
+  if (typeof event.hook_event_name !== 'string') {
+    return 'hook_event_name is required and must be a string';
+  }
+
+  if (!VALID_HOOK_EVENTS.has(event.hook_event_name)) {
+    return `Unknown hook_event_name: ${event.hook_event_name}`;
+  }
+
+  // Session ID validation
+  if (event.session_id !== undefined) {
+    if (typeof event.session_id !== 'string') {
+      return 'session_id must be a string';
+    }
+    // Alphanumeric, dots, underscores, hyphens only
+    if (!/^[a-zA-Z0-9._-]+$/.test(event.session_id)) {
+      return 'session_id contains invalid characters';
+    }
+    // Max length 128 characters
+    if (event.session_id.length > 128) {
+      return 'session_id is too long (max 128 chars)';
+    }
+  }
+
+  // CWD validation
+  if (event.cwd !== undefined) {
+    if (typeof event.cwd !== 'string') {
+      return 'cwd must be a string';
+    }
+    // Must be an absolute path
+    if (!path.isAbsolute(event.cwd)) {
+      return 'cwd must be an absolute path';
+    }
+    // Max length 1024 characters
+    if (event.cwd.length > 1024) {
+      return 'cwd is too long (max 1024 chars)';
+    }
+    // Prevent directory traversal attempts (though execFile resolves them, explicit denial is safer)
+    // Checking for '..' segments in the path string
+    if (event.cwd.split(path.sep).includes('..')) {
+      return 'cwd cannot contain traversal characters';
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix input validation on `/api/hook`

**Vulnerability:** The `/api/hook` endpoint accepted arbitrary strings for `cwd` and `session_id`, potentially allowing path traversal or shell injection if these values were used in subprocesses without sanitization (specifically `cwd` passed to `execFile` for git commands).

**Impact:** An attacker (or compromised client) could potentially execute git commands in arbitrary directories or inject malicious session IDs.

**Fix:**
- Extracted validation logic to `packages/server/src/validation.ts`.
- Enforced strict alphanumeric checks for `session_id` (max 128 chars).
- Enforced absolute path and traversal checks for `cwd` (max 1024 chars).
- Added unit tests to verify valid and invalid inputs.

**Verification:**
- `bun test packages/server/src/__tests__/validation.test.ts` passes.
- `bun test packages/server/src/__tests__/security.test.ts` passes (after temporary environment adjustment, confirmed working).

---
*PR created automatically by Jules for task [3257690507687697578](https://jules.google.com/task/3257690507687697578) started by @goggledefogger*