### PR TITLE
🛡️ Sentinel: Add strict input validation for hook events

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2025-05-23 - Hook Endpoint Input Validation
+**Vulnerability:** The `/api/hook` endpoint accepted arbitrary strings for `session_id` and `cwd` without strict validation. This could potentially allow for path traversal or injection attacks if downstream components (like git execution) relied on sanitized input, or DoS via massive payloads.
+**Learning:** Even internal endpoints (localhost) should validate input strictly. Relying on "it's just a local tool" is insufficient defense-in-depth. Extracting validation logic to a pure function makes it testable even when the server environment is complex or broken.
+**Prevention:** Implement strict schema validation for all API inputs. Use regex whitelists for identifiers and `path.isAbsolute` for file paths.

--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { validateHookEvent } from '../validation';
+
+describe('validateHookEvent', () => {
+  it('accepts valid hook event', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      session_id: 'valid.session-id_123',
+      cwd: '/absolute/path/to/project',
+    });
+    expect(error).toBeNull();
+  });
+
+  it('rejects missing hook_event_name', () => {
+    const error = validateHookEvent({
+      session_id: '123',
+    });
+    expect(error).toBe('hook_event_name is required and must be a string');
+  });
+
+  it('rejects unknown hook_event_name', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'UnknownEvent',
+      session_id: '123',
+    });
+    expect(error).toContain('Unknown hook_event_name');
+  });
+
+  it('rejects non-string session_id', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      session_id: 123,
+    });
+    expect(error).toBe('session_id must be a string');
+  });
+
+  it('rejects session_id with invalid characters', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      session_id: 'invalid/session', // forward slash not allowed
+    });
+    expect(error).toContain('session_id contains invalid characters');
+  });
+
+  it('rejects too long session_id', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      session_id: 'a'.repeat(129),
+    });
+    expect(error).toBe('session_id must be 128 characters or less');
+  });
+
+  it('rejects non-absolute cwd', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      session_id: '123',
+      cwd: 'relative/path',
+    });
+    expect(error).toBe('cwd must be an absolute path');
+  });
+
+  it('rejects too long cwd', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      session_id: '123',
+      cwd: '/' + 'a'.repeat(1024),
+    });
+    expect(error).toBe('cwd must be 1024 characters or less');
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { StateManager } from './state';
 import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
+import { validateHookEvent } from './validation';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -35,48 +36,6 @@ const hookHandler = createHookHandler(stateManager);
 app.get('/api/state', (_req, res) => {
   res.json(stateManager.getState());
 });
-
-// Allowed hook event names for validation
-const VALID_HOOK_EVENTS = new Set([
-  'PreToolUse',
-  'PostToolUse',
-  'PostToolUseFailure',
-  'PermissionRequest',
-  'SubagentStart',
-  'SubagentStop',
-  'PreCompact',
-  'Stop',
-  'SessionStart',
-  'SessionEnd',
-  'TeammateIdle',
-  'TaskCompleted',
-  'UserPromptSubmit',
-  'Notification',
-]);
-
-function validateHookEvent(event: any): string | null {
-  if (!event || typeof event !== 'object') {
-    return 'Event must be a JSON object';
-  }
-
-  if (typeof event.hook_event_name !== 'string') {
-    return 'hook_event_name is required and must be a string';
-  }
-
-  if (!VALID_HOOK_EVENTS.has(event.hook_event_name)) {
-    return `Unknown hook_event_name: ${event.hook_event_name}`;
-  }
-
-  if (event.session_id !== undefined && typeof event.session_id !== 'string') {
-    return 'session_id must be a string';
-  }
-
-  if (event.cwd !== undefined && typeof event.cwd !== 'string') {
-    return 'cwd must be a string';
-  }
-
-  return null;
-}
 
 // Hook event endpoint — receives events from Claude Code lifecycle hooks
 app.post('/api/hook', (req, res) => {

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -1,0 +1,61 @@
+import path from 'path';
+
+// Allowed hook event names for validation
+export const VALID_HOOK_EVENTS = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionRequest',
+  'SubagentStart',
+  'SubagentStop',
+  'PreCompact',
+  'Stop',
+  'SessionStart',
+  'SessionEnd',
+  'TeammateIdle',
+  'TaskCompleted',
+  'UserPromptSubmit',
+  'Notification',
+]);
+
+const SESSION_ID_REGEX = /^[a-zA-Z0-9._-]+$/;
+
+export function validateHookEvent(event: any): string | null {
+  if (!event || typeof event !== 'object') {
+    return 'Event must be a JSON object';
+  }
+
+  if (typeof event.hook_event_name !== 'string') {
+    return 'hook_event_name is required and must be a string';
+  }
+
+  if (!VALID_HOOK_EVENTS.has(event.hook_event_name)) {
+    return `Unknown hook_event_name: ${event.hook_event_name}`;
+  }
+
+  if (event.session_id !== undefined) {
+    if (typeof event.session_id !== 'string') {
+      return 'session_id must be a string';
+    }
+    if (event.session_id.length > 128) {
+      return 'session_id must be 128 characters or less';
+    }
+    if (!SESSION_ID_REGEX.test(event.session_id)) {
+       return 'session_id contains invalid characters (allowed: alphanumeric, ., _, -)';
+    }
+  }
+
+  if (event.cwd !== undefined) {
+     if (typeof event.cwd !== 'string') {
+      return 'cwd must be a string';
+    }
+    if (event.cwd.length > 1024) {
+      return 'cwd must be 1024 characters or less';
+    }
+    if (!path.isAbsolute(event.cwd)) {
+       return 'cwd must be an absolute path';
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Add strict input validation for hook events

🚨 Severity: MEDIUM (Defense in Depth)
💡 Vulnerability: The `/api/hook` endpoint accepted arbitrary strings for `session_id` and `cwd`, potentially allowing for path traversal or injection scenarios if downstream processing was flawed.
🎯 Impact: While the server runs locally, stricter validation prevents misuse and reduces the attack surface.
🔧 Fix: Implemented strict validation (regex for IDs, absolute path check for CWD, length limits) in a standalone, testable module.
✅ Verification: Added unit tests in `packages/server/src/__tests__/validation.test.ts` covering edge cases. Verified with `bun test`.

---
*PR created automatically by Jules for task [10865202321930795575](https://jules.google.com/task/10865202321930795575) started by @goggledefogger*