### PR TITLE
⚡ Optimize NavigationTree re-renders by extracting relative timestamps

### DIFF
--- a/packages/client/src/components/AgentDetail.tsx
+++ b/packages/client/src/components/AgentDetail.tsx
@@ -1,13 +1,6 @@
 import type { AgentState, TaskState } from '@agent-viewer/shared';
 import { getBranchColor } from '../constants/colors';
-
-/** Format a relative time string from a timestamp */
-function relativeTime(ts: number): string {
-  const diff = Math.floor((Date.now() - ts) / 1000);
-  if (diff < 60) return `${diff}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  return `${Math.floor(diff / 3600)}h ago`;
-}
+import { relativeTime } from './RelativeTime';
 
 /** Word-wrap text into lines of maxLen chars */
 function wrapText(text: string, maxLen: number): string[] {

--- a/packages/client/src/components/NavigationTree.tsx
+++ b/packages/client/src/components/NavigationTree.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import type { ProjectGroup, BranchGroup, SessionListEntry } from '@agent-viewer/shared';
 import type { ZoomLevel } from '../hooks/useNavigation';
+import { RelativeTime } from './RelativeTime';
 
 interface NavigationTreeProps {
   zoomLevel: ZoomLevel;
@@ -16,15 +17,6 @@ interface NavigationTreeProps {
   onSearchChange: (filter: string) => void;
   onToggleHideIdle: () => void;
   onClose: () => void;
-}
-
-function relativeTime(timestamp: number): string {
-  const delta = Math.floor((Date.now() - timestamp) / 1000);
-  if (delta < 5) return 'just now';
-  if (delta < 60) return `${delta}s ago`;
-  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
-  if (delta < 86400) return `${Math.floor(delta / 3600)}h ago`;
-  return `${Math.floor(delta / 86400)}d ago`;
 }
 
 function WaitingDot() {
@@ -49,14 +41,6 @@ export function NavigationTree({
   const panelRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const [focusIndex, setFocusIndex] = useState(-1);
-  const [, setTick] = useState(0);
-
-  // Update relative timestamps periodically
-  useEffect(() => {
-    if (!isOpen) return;
-    const interval = setInterval(() => setTick((t) => t + 1), 5000);
-    return () => clearInterval(interval);
-  }, [isOpen]);
 
   // Focus search on open
   useEffect(() => {
@@ -268,7 +252,7 @@ export function NavigationTree({
                   <span className="nav-session-waiting-label">Waiting</span>
                 </>
               )}
-              <span className="nav-session-time">{relativeTime(session.lastActivity)}</span>
+              <RelativeTime timestamp={session.lastActivity} className="nav-session-time" />
             </div>
           </button>
         ))}

--- a/packages/client/src/components/RelativeTime.tsx
+++ b/packages/client/src/components/RelativeTime.tsx
@@ -1,0 +1,28 @@
+import { useTick } from '../hooks/useTick';
+
+/**
+ * Formats a timestamp as a relative time string (e.g., "5m ago").
+ */
+export function relativeTime(timestamp: number): string {
+  const delta = Math.floor((Date.now() - timestamp) / 1000);
+  if (delta < 5) return 'just now';
+  if (delta < 60) return `${delta}s ago`;
+  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
+  if (delta < 86400) return `${Math.floor(delta / 3600)}h ago`;
+  return `${Math.floor(delta / 86400)}d ago`;
+}
+
+interface RelativeTimeProps {
+  timestamp: number;
+  className?: string;
+}
+
+/**
+ * A component that displays a relative time and updates every 5 seconds.
+ * By using this component, periodic updates are isolated and do not cause
+ * parent components to re-render.
+ */
+export function RelativeTime({ timestamp, className }: RelativeTimeProps) {
+  useTick();
+  return <span className={className}>{relativeTime(timestamp)}</span>;
+}

--- a/packages/client/src/components/SessionPicker.tsx
+++ b/packages/client/src/components/SessionPicker.tsx
@@ -1,32 +1,17 @@
 import { useState, useEffect, useRef } from 'react';
 import type { SessionListEntry } from '@agent-viewer/shared';
+import { RelativeTime } from './RelativeTime';
 
 interface SessionPickerProps {
   sessions: SessionListEntry[];
   onSelect: (sessionId: string) => void;
 }
 
-function relativeTime(timestamp: number): string {
-  const delta = Math.floor((Date.now() - timestamp) / 1000);
-  if (delta < 5) return 'just now';
-  if (delta < 60) return `${delta}s ago`;
-  if (delta < 3600) return `${Math.floor(delta / 60)}m ago`;
-  if (delta < 86400) return `${Math.floor(delta / 3600)}h ago`;
-  return `${Math.floor(delta / 86400)}d ago`;
-}
-
 export function SessionPicker({ sessions, onSelect }: SessionPickerProps) {
   const [open, setOpen] = useState(false);
-  const [, setTick] = useState(0);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const active = sessions.find((s) => s.active);
-
-  // Update relative timestamps every 5 seconds
-  useEffect(() => {
-    const interval = setInterval(() => setTick((t) => t + 1), 5000);
-    return () => clearInterval(interval);
-  }, []);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -94,7 +79,7 @@ export function SessionPicker({ sessions, onSelect }: SessionPickerProps) {
                 {s.gitBranch && (
                   <span className="badge badge-branch">{s.gitBranch}</span>
                 )}
-                <span className="session-picker-time">{relativeTime(s.lastActivity)}</span>
+                <RelativeTime timestamp={s.lastActivity} className="session-picker-time" />
               </div>
             </button>
           ))}

--- a/packages/client/src/hooks/useTick.ts
+++ b/packages/client/src/hooks/useTick.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+let globalTick = 0;
+const subscribers = new Set<() => void>();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function startTimer() {
+  if (intervalId) return;
+  intervalId = setInterval(() => {
+    globalTick++;
+    subscribers.forEach((callback) => callback());
+  }, 5000);
+}
+
+function stopTimer() {
+  if (intervalId && subscribers.size === 0) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+/**
+ * A hook that provides a periodic update every 5 seconds.
+ * Multiple components using this hook share a single interval.
+ */
+export function useTick() {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const callback = () => setTick((t) => t + 1);
+    subscribers.add(callback);
+    startTimer();
+
+    return () => {
+      subscribers.delete(callback);
+      stopTimer();
+    };
+  }, []);
+
+  return globalTick;
+}


### PR DESCRIPTION
This PR improves the performance of the session navigation tree by isolating periodic timestamp updates.

Previously, the entire `NavigationTree` component re-rendered every 5 seconds to update relative time strings (e.g., "5m ago"). This was inefficient as the tree can contain many elements and complex logic.

The optimization consists of:
1. **`useTick` Hook**: A new hook that uses a single global `setInterval`. Multiple components can subscribe to this hook to receive a periodic update without creating multiple timers.
2. **`RelativeTime` Component**: A small leaf component that uses `useTick` to update itself. By using this component in `NavigationTree` and `SessionPicker`, we ensure that only these small components re-render every 5 seconds, rather than their large parent components.
3. **Unification**: Consolidated the `relativeTime` utility function into `RelativeTime.tsx`, removing duplication and inconsistencies in `NavigationTree`, `SessionPicker`, and `AgentDetail`.

**Performance Impact:**
- **Re-render Isolation**: Periodic updates no longer trigger re-renders of the large `NavigationTree` component tree.
- **Resource Efficiency**: Multiple intervals are replaced by a single shared timer, reducing background CPU usage.

---
*PR created automatically by Jules for task [18281086516040050694](https://jules.google.com/task/18281086516040050694) started by @goggledefogger*