### PR TITLE
🧹 Refactor agent waiting and activity logic to use ID-based methods

### DIFF
--- a/packages/server/src/state.ts
+++ b/packages/server/src/state.ts
@@ -186,41 +186,11 @@ export class StateManager {
   }
 
   updateAgentActivity(agentName: string, status: 'idle' | 'working' | 'done', action?: string, actionContext?: string) {
-    // Update in the full registry
-    let registryAgent: AgentState | undefined;
     for (const agent of this.allAgents.values()) {
       if (agent.name === agentName) {
-        agent.status = status;
-        agent.currentAction = action;
-        agent.actionContext = actionContext;
-        // Clear waiting flag when going idle or done
-        if (status === 'idle' || status === 'done') {
-          agent.waitingForInput = false;
-          agent.waitingType = undefined;
-        }
-        // Push to recent actions ring buffer
-        if (action && status === 'working') {
-          this.pushRecentAction(agent, action);
-        }
-        registryAgent = agent;
-        break;
+        this.updateAgentActivityById(agent.id, status, action, actionContext);
+        return;
       }
-    }
-    // Update in the displayed state
-    const agent = this.state.agents.find((a) => a.name === agentName);
-    if (agent) {
-      agent.status = status;
-      agent.currentAction = action;
-      agent.actionContext = actionContext;
-      if (status === 'idle' || status === 'done') {
-        agent.waitingForInput = false;
-        agent.waitingType = undefined;
-      }
-    }
-    // Broadcast using displayed entry or allAgents entry
-    const broadcastAgent = agent || registryAgent;
-    if (broadcastAgent) {
-      this.broadcast({ type: 'agent_update', data: broadcastAgent });
     }
   }
 
@@ -299,28 +269,11 @@ export class StateManager {
   }
 
   setAgentWaiting(agentName: string, waiting: boolean, action?: string, actionContext?: string) {
-    // Update in the full registry
-    let registryAgent: AgentState | undefined;
     for (const agent of this.allAgents.values()) {
       if (agent.name === agentName) {
-        agent.waitingForInput = waiting;
-        if (action) agent.currentAction = action;
-        if (actionContext !== undefined) agent.actionContext = actionContext;
-        registryAgent = agent;
-        break;
+        this.setAgentWaitingById(agent.id, waiting, action, actionContext);
+        return;
       }
-    }
-    // Update in the displayed state
-    const agent = this.state.agents.find((a) => a.name === agentName);
-    if (agent) {
-      agent.waitingForInput = waiting;
-      if (action) agent.currentAction = action;
-      if (actionContext !== undefined) agent.actionContext = actionContext;
-    }
-    // Broadcast using displayed entry or allAgents entry
-    const broadcastAgent = agent || registryAgent;
-    if (broadcastAgent) {
-      this.broadcast({ type: 'agent_update', data: broadcastAgent });
     }
   }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was duplicate logic in `setAgentWaiting` and `updateAgentActivity` within the `StateManager` class.
💡 **Why:** This improves maintainability by centralizing the update and broadcast logic in a single place (the ID-based methods), ensuring that name-based updates benefit from the same robust handling (such as debouncing and cross-session safety).
✅ **Verification:** Confirmed the refactoring by running `packages/server/src/__tests__/state.test.ts` with `bun test`. 124 tests passed, including all tests covering the refactored methods.
✨ **Result:** Reduced code duplication and improved consistency in state management.

---
*PR created automatically by Jules for task [2556704375496029212](https://jules.google.com/task/2556704375496029212) started by @goggledefogger*