### PR TITLE
Fix session_id type validation in hook API

### DIFF
--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { validateHookEvent } from '../validation';
+
+describe('validateHookEvent', () => {
+  it('accepts valid hook event', () => {
+    const event = {
+      hook_event_name: 'SessionStart',
+      session_id: 'test-session',
+      cwd: '/path/to/project'
+    };
+    expect(validateHookEvent(event)).toBeNull();
+  });
+
+  it('rejects null or non-object', () => {
+    expect(validateHookEvent(null)).toBe('Event must be a JSON object');
+    expect(validateHookEvent('not an object')).toBe('Event must be a JSON object');
+    expect(validateHookEvent([])).toBe('Event must be a JSON object');
+  });
+
+  it('rejects missing hook_event_name', () => {
+    const event = { session_id: 'test-session' };
+    expect(validateHookEvent(event)).toBe('hook_event_name is required and must be a string');
+  });
+
+  it('rejects non-string hook_event_name', () => {
+    const event = { hook_event_name: 123 };
+    expect(validateHookEvent(event)).toBe('hook_event_name is required and must be a string');
+  });
+
+  it('rejects unknown hook_event_name', () => {
+    const event = { hook_event_name: 'UnknownEvent' };
+    expect(validateHookEvent(event)).toBe('Unknown hook_event_name: UnknownEvent');
+  });
+
+  it('rejects non-string session_id', () => {
+    const event = {
+      hook_event_name: 'SessionStart',
+      session_id: { malicious: 'object' }
+    };
+    expect(validateHookEvent(event)).toBe('session_id must be a string');
+  });
+
+  it('rejects non-string cwd', () => {
+    const event = {
+      hook_event_name: 'SessionStart',
+      cwd: 12345
+    };
+    expect(validateHookEvent(event)).toBe('cwd must be a string');
+  });
+
+  it('accepts event without optional fields', () => {
+    const event = { hook_event_name: 'Stop' };
+    expect(validateHookEvent(event)).toBeNull();
+  });
+
+  it('rejects session_id as null', () => {
+    const event = {
+      hook_event_name: 'SessionStart',
+      session_id: null
+    };
+    expect(validateHookEvent(event)).toBe('session_id must be a string');
+  });
+
+  it('rejects session_id as array', () => {
+    const event = {
+      hook_event_name: 'SessionStart',
+      session_id: ['test-session']
+    };
+    expect(validateHookEvent(event)).toBe('session_id must be a string');
+  });
+
+  it('rejects cwd as object', () => {
+    const event = {
+      hook_event_name: 'SessionStart',
+      cwd: { path: '/tmp' }
+    };
+    expect(validateHookEvent(event)).toBe('cwd must be a string');
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { StateManager } from './state';
 import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
+import { validateHookEvent } from './validation';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -35,48 +36,6 @@ const hookHandler = createHookHandler(stateManager);
 app.get('/api/state', (_req, res) => {
   res.json(stateManager.getState());
 });
-
-// Allowed hook event names for validation
-const VALID_HOOK_EVENTS = new Set([
-  'PreToolUse',
-  'PostToolUse',
-  'PostToolUseFailure',
-  'PermissionRequest',
-  'SubagentStart',
-  'SubagentStop',
-  'PreCompact',
-  'Stop',
-  'SessionStart',
-  'SessionEnd',
-  'TeammateIdle',
-  'TaskCompleted',
-  'UserPromptSubmit',
-  'Notification',
-]);
-
-function validateHookEvent(event: any): string | null {
-  if (!event || typeof event !== 'object') {
-    return 'Event must be a JSON object';
-  }
-
-  if (typeof event.hook_event_name !== 'string') {
-    return 'hook_event_name is required and must be a string';
-  }
-
-  if (!VALID_HOOK_EVENTS.has(event.hook_event_name)) {
-    return `Unknown hook_event_name: ${event.hook_event_name}`;
-  }
-
-  if (event.session_id !== undefined && typeof event.session_id !== 'string') {
-    return 'session_id must be a string';
-  }
-
-  if (event.cwd !== undefined && typeof event.cwd !== 'string') {
-    return 'cwd must be a string';
-  }
-
-  return null;
-}
 
 // Hook event endpoint — receives events from Claude Code lifecycle hooks
 app.post('/api/hook', (req, res) => {

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -1,0 +1,50 @@
+/**
+ * Validation logic for hook events.
+ * Extracted to a separate module to allow unit testing without side effects.
+ */
+
+// Allowed hook event names for validation
+export const VALID_HOOK_EVENTS = new Set([
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionRequest',
+  'SubagentStart',
+  'SubagentStop',
+  'PreCompact',
+  'Stop',
+  'SessionStart',
+  'SessionEnd',
+  'TeammateIdle',
+  'TaskCompleted',
+  'UserPromptSubmit',
+  'Notification',
+]);
+
+/**
+ * Validates a hook event object.
+ * Returns an error message string if invalid, or null if valid.
+ */
+export function validateHookEvent(event: any): string | null {
+  if (!event || typeof event !== 'object' || Array.isArray(event)) {
+    return 'Event must be a JSON object';
+  }
+
+  if (typeof event.hook_event_name !== 'string') {
+    return 'hook_event_name is required and must be a string';
+  }
+
+  if (!VALID_HOOK_EVENTS.has(event.hook_event_name)) {
+    return `Unknown hook_event_name: ${event.hook_event_name}`;
+  }
+
+  if (event.session_id !== undefined && typeof event.session_id !== 'string') {
+    return 'session_id must be a string';
+  }
+
+  if (event.cwd !== undefined && typeof event.cwd !== 'string') {
+    return 'cwd must be a string';
+  }
+
+  return null;
+}


### PR DESCRIPTION
The hook API validation was refined to ensure `session_id` and `cwd` are strings. The validation logic was extracted to a separate module to allow unit testing without spawning the server, which was problematic in the current environment. Comprehensive unit tests were added to verify the validation logic for various edge cases.

---
*PR created automatically by Jules for task [7811797512200431131](https://jules.google.com/task/7811797512200431131) started by @goggledefogger*