### PR TITLE
🛡️ Sentinel: [CRITICAL] Add optional authentication to API and WebSocket endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2026-02-14 - Integration Tests vs Unit Tests in Restricted Env
+**Vulnerability:** Process vulnerability. Integration tests spawning server processes failed due to `ERR_MODULE_NOT_FOUND` in restricted environment.
+**Learning:** `spawn`ing `tsx` requires full `node_modules` resolution which can be flaky in restricted envs.
+**Prevention:** Prefer unit tests that mock Express/HTTP objects over integration tests that spawn processes, especially for logic like middleware.

--- a/hooks/agent-viewer-hook.sh
+++ b/hooks/agent-viewer-hook.sh
@@ -17,13 +17,23 @@
 # - Fast (1s timeout for HTTP request)
 
 PORT="${AGENT_VIEWER_PORT:-3001}"
+TOKEN="${AGENT_VIEWER_TOKEN}"
 INPUT=$(cat)
 
 # Fire-and-forget POST to the server
-curl -sS -X POST "http://localhost:${PORT}/api/hook" \
-  -H "Content-Type: application/json" \
-  -d "$INPUT" \
-  --max-time 1 \
-  >/dev/null 2>&1 || true
+if [ -n "$TOKEN" ]; then
+  curl -sS -X POST "http://localhost:${PORT}/api/hook" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -d "$INPUT" \
+    --max-time 1 \
+    >/dev/null 2>&1 || true
+else
+  curl -sS -X POST "http://localhost:${PORT}/api/hook" \
+    -H "Content-Type: application/json" \
+    -d "$INPUT" \
+    --max-time 1 \
+    >/dev/null 2>&1 || true
+fi
 
 exit 0

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -64,8 +64,12 @@ function LiveIndicator({ lastActivity }: { lastActivity?: number }) {
   );
 }
 
+const WS_URL = 'ws://localhost:3001/ws';
+const TOKEN = import.meta.env.VITE_AUTH_TOKEN;
+const url = TOKEN ? `${WS_URL}?token=${TOKEN}` : WS_URL;
+
 export default function App() {
-  const { team: state, sessions, groupedSessions, connectionStatus, selectSession } = useWebSocket('ws://localhost:3001/ws');
+  const { team: state, sessions, groupedSessions, connectionStatus, selectSession } = useWebSocket(url);
   const notifications = useNotifications(state.agents, state.session, sessions);
   const navigation = useNavigation(groupedSessions, state.session);
   const inbox = useInbox(state.agents, state.session, sessions);

--- a/packages/server/src/__tests__/auth.test.ts
+++ b/packages/server/src/__tests__/auth.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { requireAuth, validateWebSocketAuth } from '../auth';
+import type { Request, Response, NextFunction } from 'express';
+import type { IncomingMessage } from 'http';
+
+describe('Auth Middleware', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('requireAuth', () => {
+    it('allows access when AUTH_TOKEN is not set', () => {
+      delete process.env.AUTH_TOKEN;
+      const req = { headers: {}, query: {} } as unknown as Request;
+      const res = {} as unknown as Response;
+      const next = vi.fn();
+
+      requireAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('rejects request without token when AUTH_TOKEN is set', () => {
+      process.env.AUTH_TOKEN = 'secret';
+      const req = { headers: {}, query: {} } as unknown as Request;
+      const status = vi.fn().mockReturnThis();
+      const json = vi.fn();
+      const res = { status, json } as unknown as Response;
+      const next = vi.fn();
+
+      requireAuth(req, res, next);
+      expect(next).not.toHaveBeenCalled();
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('rejects request with invalid token', () => {
+      process.env.AUTH_TOKEN = 'secret';
+      const req = { headers: { authorization: 'Bearer wrong' }, query: {} } as unknown as Request;
+      const status = vi.fn().mockReturnThis();
+      const json = vi.fn();
+      const res = { status, json } as unknown as Response;
+      const next = vi.fn();
+
+      requireAuth(req, res, next);
+      expect(status).toHaveBeenCalledWith(401);
+    });
+
+    it('accepts request with valid Bearer token', () => {
+      process.env.AUTH_TOKEN = 'secret';
+      const req = { headers: { authorization: 'Bearer secret' }, query: {} } as unknown as Request;
+      const res = {} as unknown as Response;
+      const next = vi.fn();
+
+      requireAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('accepts request with valid query token', () => {
+      process.env.AUTH_TOKEN = 'secret';
+      const req = { headers: {}, query: { token: 'secret' } } as unknown as Request;
+      const res = {} as unknown as Response;
+      const next = vi.fn();
+
+      requireAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('validateWebSocketAuth', () => {
+    it('allows connection when AUTH_TOKEN is not set', () => {
+      delete process.env.AUTH_TOKEN;
+      const req = { headers: {}, url: '/ws' } as unknown as IncomingMessage;
+      expect(validateWebSocketAuth(req)).toBe(true);
+    });
+
+    it('rejects connection without token when AUTH_TOKEN is set', () => {
+      process.env.AUTH_TOKEN = 'secret';
+      const req = { headers: { host: 'localhost' }, url: '/ws' } as unknown as IncomingMessage;
+      expect(validateWebSocketAuth(req)).toBe(false);
+    });
+
+    it('accepts connection with valid query token', () => {
+      process.env.AUTH_TOKEN = 'secret';
+      const req = { headers: { host: 'localhost' }, url: '/ws?token=secret' } as unknown as IncomingMessage;
+      expect(validateWebSocketAuth(req)).toBe(true);
+    });
+
+    it('accepts connection with valid Authorization header', () => {
+      process.env.AUTH_TOKEN = 'secret';
+      const req = { headers: { host: 'localhost', authorization: 'Bearer secret' }, url: '/ws' } as unknown as IncomingMessage;
+      expect(validateWebSocketAuth(req)).toBe(true);
+    });
+  });
+});

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,0 +1,46 @@
+import { Request, Response, NextFunction } from 'express';
+import { IncomingMessage } from 'http';
+import { URL } from 'url';
+
+/**
+ * Middleware to enforce authentication if AUTH_TOKEN is set.
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction) {
+  const authToken = process.env.AUTH_TOKEN;
+  if (!authToken) {
+    return next();
+  }
+
+  const authHeader = req.headers.authorization;
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : req.query.token;
+
+  if (token !== authToken) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  next();
+}
+
+/**
+ * Validator for WebSocket upgrade requests.
+ * Returns true if authorized, false otherwise.
+ */
+export function validateWebSocketAuth(req: IncomingMessage): boolean {
+  const authToken = process.env.AUTH_TOKEN;
+  if (!authToken) {
+    return true;
+  }
+
+  // Parse query params from URL
+  // req.url is relative, e.g., '/ws?token=xyz'
+  const url = new URL(req.url || '', `http://${req.headers.host}`);
+  const token = url.searchParams.get('token');
+
+  // Also check headers? Standard WS doesn't support custom headers well in browser API,
+  // but some clients might send 'Authorization'.
+  // ws library puts headers in req.headers
+  const authHeader = req.headers['authorization'];
+  const headerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+
+  return token === authToken || headerToken === authToken;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,10 +1,11 @@
 import express from 'express';
-import { createServer } from 'http';
+import { createServer, IncomingMessage } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { StateManager } from './state';
 import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
 import { validateHookEvent } from './validation';
+import { requireAuth, validateWebSocketAuth } from './auth';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -25,6 +26,9 @@ app.use((_req, res, next) => {
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: Date.now() });
 });
+
+// Protect all other API routes
+app.use('/api', requireAuth);
 
 // JSON body parsing for hook events
 app.use(express.json({ limit: '1mb' }));
@@ -94,7 +98,13 @@ function getClientActiveSessionId(ws: WebSocket): string | undefined {
   return clientStates.get(ws)?.selectedSessionId || stateManager.getDefaultSessionId();
 }
 
-wss.on('connection', (ws: WebSocket) => {
+wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+  if (!validateWebSocketAuth(req)) {
+    console.warn('[ws] unauthorized connection attempt');
+    ws.close(1008, 'Unauthorized');
+    return;
+  }
+
   console.log('[ws] client connected');
   // Pick the most interesting session for this new client, rather than using
   // the global default (which may be stale from a previous client's navigation).


### PR DESCRIPTION
Implemented optional token-based authentication for the Agent Viewer server.

## Security Improvement
Added `requireAuth` middleware to the server which checks for a valid `AUTH_TOKEN` environment variable. If set, requests must provide the token via `Authorization: Bearer <token>` header or `token` query parameter. This protects sensitive endpoints like `/api/hook` (which can trigger git commands) and `/api/state`.

## Changes
- **Server:** Added `auth.ts` logic and applied it in `index.ts`.
- **Client:** Updated `App.tsx` to use `VITE_AUTH_TOKEN` when connecting to WebSocket.
- **Hooks:** Updated `agent-viewer-hook.sh` to send the token if `AGENT_VIEWER_TOKEN` is set.
- **Tests:** Added `auth.test.ts` to verify the middleware logic (unit tests mocking Express).

## Verification
Ran `npx vitest run packages/server/src/__tests__/auth.test.ts` and confirmed all tests pass. Tested scenarios:
- Token not set (access allowed)
- Token set, request missing token (access denied)
- Token set, request has valid token (access allowed)


---
*PR created automatically by Jules for task [495225191092736190](https://jules.google.com/task/495225191092736190) started by @goggledefogger*