### PR TITLE
🛡️ Sentinel: [ENHANCEMENT] Add optional token-based authentication

### DIFF
--- a/hooks/agent-viewer-hook.sh
+++ b/hooks/agent-viewer-hook.sh
@@ -19,11 +19,16 @@
 PORT="${AGENT_VIEWER_PORT:-3001}"
 INPUT=$(cat)
 
+# Build curl arguments
+CURL_ARGS=(-sS -X POST "http://localhost:${PORT}/api/hook" -H "Content-Type: application/json")
+
+if [ -n "$AGENT_VIEWER_TOKEN" ]; then
+  CURL_ARGS+=(-H "Authorization: Bearer $AGENT_VIEWER_TOKEN")
+fi
+
+CURL_ARGS+=(-d "$INPUT" --max-time 1)
+
 # Fire-and-forget POST to the server
-curl -sS -X POST "http://localhost:${PORT}/api/hook" \
-  -H "Content-Type: application/json" \
-  -d "$INPUT" \
-  --max-time 1 \
-  >/dev/null 2>&1 || true
+curl "${CURL_ARGS[@]}" >/dev/null 2>&1 || true
 
 exit 0

--- a/packages/client/src/hooks/useWebSocket.ts
+++ b/packages/client/src/hooks/useWebSocket.ts
@@ -41,7 +41,14 @@ export function useWebSocket(url: string): WebSocketState {
   }, []);
 
   const connect = useCallback(() => {
-    const ws = new WebSocket(url);
+    let wsUrl = url;
+    const token = import.meta.env.VITE_AUTH_TOKEN;
+    if (token) {
+      const separator = wsUrl.includes('?') ? '&' : '?';
+      wsUrl = `${wsUrl}${separator}token=${encodeURIComponent(token)}`;
+    }
+
+    const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 
     ws.onopen = () => {

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,0 +1,57 @@
+import { Request, Response, NextFunction } from 'express';
+import { IncomingMessage } from 'http';
+import { URL } from 'url';
+
+/**
+ * Validates a token against the server's configured AUTH_TOKEN.
+ * If AUTH_TOKEN is not set, authentication is disabled (always returns true).
+ */
+export function validateToken(token?: string): boolean {
+  const serverToken = process.env.AUTH_TOKEN;
+  if (!serverToken) {
+    return true; // Auth disabled
+  }
+  // Constant-time comparison could be better but strict equality is acceptable for this scope
+  return token === serverToken;
+}
+
+/**
+ * Express middleware to enforce authentication.
+ * Checks for Bearer token in Authorization header or 'token' query parameter.
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction) {
+  const serverToken = process.env.AUTH_TOKEN;
+  if (!serverToken) {
+    return next();
+  }
+
+  let token = req.query.token as string;
+
+  if (!token) {
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+      token = authHeader.substring(7);
+    }
+  }
+
+  if (validateToken(token)) {
+    next();
+  } else {
+    res.status(401).json({ ok: false, error: 'Unauthorized' });
+  }
+}
+
+/**
+ * Extract token from WebSocket upgrade request
+ */
+export function getTokenFromRequest(req: IncomingMessage): string | undefined {
+  if (!req.url) return undefined;
+
+  try {
+    // Parse URL relative to a dummy base since req.url is just the path
+    const url = new URL(req.url, 'http://localhost');
+    return url.searchParams.get('token') || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,7 @@ import { StateManager } from './state';
 import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
 import { validateHookEvent } from './validation';
+import { requireAuth, validateToken, getTokenFromRequest } from './auth';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -33,12 +34,12 @@ app.use(express.json({ limit: '1mb' }));
 const stateManager = new StateManager();
 const hookHandler = createHookHandler(stateManager);
 
-app.get('/api/state', (_req, res) => {
+app.get('/api/state', requireAuth, (_req, res) => {
   res.json(stateManager.getState());
 });
 
 // Hook event endpoint — receives events from Claude Code lifecycle hooks
-app.post('/api/hook', (req, res) => {
+app.post('/api/hook', requireAuth, (req, res) => {
   try {
     const event = req.body;
 
@@ -60,12 +61,23 @@ app.post('/api/hook', (req, res) => {
 });
 
 // Sessions list endpoint
-app.get('/api/sessions', (_req, res) => {
+app.get('/api/sessions', requireAuth, (_req, res) => {
   res.json(stateManager.getSessionsList());
 });
 
 // WebSocket server — per-client session tracking for multi-tab support
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({
+  server,
+  path: '/ws',
+  verifyClient: (info, cb) => {
+    const token = getTokenFromRequest(info.req);
+    if (validateToken(token)) {
+      cb(true);
+    } else {
+      cb(false, 401, 'Unauthorized');
+    }
+  },
+});
 
 /** Per-client state: tracks which session each WebSocket client has selected */
 interface ClientState {


### PR DESCRIPTION
Implemented optional token-based authentication for the server, client, and hooks.

1.  **Server**: Added `auth.ts` middleware and updated `index.ts` to protect `/api/state`, `/api/sessions`, `/api/hook` and WebSocket connections.
2.  **Client**: Updated `useWebSocket.ts` to include `?token=...` in the WebSocket URL.
3.  **Hooks**: Updated `agent-viewer-hook.sh` to include `Authorization: Bearer ...` header.

Authentication is triggered only when the `AUTH_TOKEN` environment variable is set on the server. If not set, the system remains open (dev mode). Users must set `VITE_AUTH_TOKEN` (client) and `AGENT_VIEWER_TOKEN` (hooks) to match the server token.

---
*PR created automatically by Jules for task [10017232824976688609](https://jules.google.com/task/10017232824976688609) started by @goggledefogger*