### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability in hook validation

### DIFF
--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -82,4 +82,12 @@ describe('validateHookEvent', () => {
     });
     expect(error).toMatch(/cwd is too long/);
   });
+
+  it('validates cwd path traversal', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/absolute/path/../to/traversal',
+    });
+    expect(error).toMatch(/cwd must be a normalized path/);
+  });
 });

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -57,6 +57,9 @@ export function validateHookEvent(event: any): string | null {
     if (event.cwd.includes('\0')) {
         return 'cwd must not contain null bytes';
     }
+    if (path.normalize(event.cwd) !== event.cwd) {
+      return 'cwd must be a normalized path';
+    }
   }
 
   return null;


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability in hook validation

🚨 Severity: HIGH
💡 Vulnerability: The `cwd` field in hook events was only checked for absolute path format, potentially allowing path traversal sequences (e.g., `/foo/../bar`) if processed by naive file system operations.
🎯 Impact: Could allow an attacker (or compromised hook source) to reference files outside the intended directory scope if the `cwd` is used in file operations without further sanitization.
🔧 Fix: Added a strict check using `path.normalize()` to ensure the `cwd` path is canonical and contains no `..` segments.
✅ Verification: Added unit tests in `packages/server/src/__tests__/validation.test.ts` that specifically attempt path traversal and confirm they are rejected. Run `npx vitest run packages/server/src/__tests__/validation.test.ts` to verify.

---
*PR created automatically by Jules for task [9471733117256292455](https://jules.google.com/task/9471733117256292455) started by @goggledefogger*