### PR TITLE
Add multi-panel dashboard view for monitoring multiple sessions

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -4,10 +4,12 @@ import { Sidebar } from './components/Sidebar';
 import { AlertBar } from './components/AlertBar';
 import { Breadcrumb } from './components/Breadcrumb';
 import { NavigationTree } from './components/NavigationTree';
+import { DashboardGrid } from './components/DashboardGrid';
 import { useWebSocket } from './hooks/useWebSocket';
 import { useNotifications } from './hooks/useNotifications';
 import { useNavigation } from './hooks/useNavigation';
 import { useInbox } from './hooks/useInbox';
+import { useDashboard } from './hooks/useDashboard';
 import type { ConnectionStatus } from './hooks/useWebSocket';
 
 type MobileTab = 'scene' | 'inbox' | 'tasks' | 'messages';
@@ -65,13 +67,37 @@ function LiveIndicator({ lastActivity }: { lastActivity?: number }) {
 }
 
 export default function App() {
-  const { team: state, sessions, groupedSessions, connectionStatus, selectSession } = useWebSocket('ws://localhost:3001/ws');
+  const { team: state, sessions, groupedSessions, connectionStatus, selectSession, setDashboard, setDashboardCallbacks } = useWebSocket('ws://localhost:3001/ws');
   const notifications = useNotifications(state.agents, state.session, sessions);
   const navigation = useNavigation(groupedSessions, state.session);
   const inbox = useInbox(state.agents, state.session, sessions);
+  const dashboard = useDashboard();
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mobileTab, setMobileTab] = useState<MobileTab>('scene');
   const isMobile = useIsMobile();
+
+  // Wire dashboard callbacks to useWebSocket
+  useEffect(() => {
+    if (dashboard.active) {
+      setDashboardCallbacks({
+        onDashboardStates: dashboard.applyDashboardStates,
+        onDashboardUpdate: dashboard.applyDashboardUpdate,
+      });
+    } else {
+      setDashboardCallbacks(null);
+    }
+  }, [dashboard.active, dashboard.applyDashboardStates, dashboard.applyDashboardUpdate, setDashboardCallbacks]);
+
+  // Handle dashboard focus (double-click a panel to enter single-view)
+  useEffect(() => {
+    if (dashboard.focusedSessionId) {
+      selectSession(dashboard.focusedSessionId);
+      dashboard.clearFocus();
+      // Turn off dashboard mode
+      const ids = dashboard.toggle(sessions);
+      if (ids) setDashboard(ids);
+    }
+  }, [dashboard.focusedSessionId, selectSession, dashboard, sessions, setDashboard]);
 
   const session = state.session;
   const isSolo = session ? !session.isTeam : state.agents.length <= 1;
@@ -111,33 +137,68 @@ export default function App() {
     setTimeout(() => setHighlightTaskId(null), 2200);
   }, [isMobile]);
 
+  // Toggle dashboard mode
+  const handleToggleDashboard = useCallback(() => {
+    const sessionIds = dashboard.toggle(sessions);
+    if (sessionIds) {
+      // Turned on: subscribe to all sessions
+      setDashboard(sessionIds);
+    } else {
+      // Turned off: clear dashboard subscription, back to single-view
+      setDashboard([]);
+    }
+  }, [dashboard, sessions, setDashboard]);
+
+  // Remove a panel from the dashboard
+  const handleRemovePanel = useCallback((sessionId: string) => {
+    const remaining = dashboard.removePanel(sessionId);
+    if (remaining) {
+      setDashboard(remaining);
+    } else {
+      // All panels removed — exit dashboard mode
+      setDashboard([]);
+    }
+  }, [dashboard, setDashboard]);
+
   // Always show navigation breadcrumb when there are sessions
   const showNavigation = sessions.length >= 1;
+  // Show dashboard toggle when there are 2+ sessions
+  const showDashboardToggle = sessions.length >= 2;
 
   return (
     <div className="app-wrapper">
-      <AlertBar
-        waitingAgents={notifications.waitingAgents}
-        onFocusAgent={handleFocusAgent}
-      />
+      {!dashboard.active && (
+        <AlertBar
+          waitingAgents={notifications.waitingAgents}
+          onFocusAgent={handleFocusAgent}
+        />
+      )}
       <header className="app-header">
         <div className="header-left">
           <ConnectionDot status={connectionStatus} />
-          <span className="header-team-name">
-            {state.name || 'Agent Viewer Town'}
-          </span>
-          {session && (
+          {dashboard.active ? (
+            <span className="header-team-name">
+              All Sessions ({dashboard.panels.length})
+            </span>
+          ) : (
             <>
-              <LiveIndicator lastActivity={session.lastActivity} />
-              <span className={`badge ${isSolo ? 'badge-solo' : 'badge-team'}`}>
-                {isSolo ? 'Solo' : `Team (${state.agents.length})`}
+              <span className="header-team-name">
+                {state.name || 'Agent Viewer Town'}
               </span>
-              {session.gitBranch && (
-                <span className="badge badge-branch">{session.gitBranch}</span>
+              {session && (
+                <>
+                  <LiveIndicator lastActivity={session.lastActivity} />
+                  <span className={`badge ${isSolo ? 'badge-solo' : 'badge-team'}`}>
+                    {isSolo ? 'Solo' : `Team (${state.agents.length})`}
+                  </span>
+                  {session.gitBranch && (
+                    <span className="badge badge-branch">{session.gitBranch}</span>
+                  )}
+                </>
               )}
             </>
           )}
-          {showNavigation ? (
+          {showNavigation && !dashboard.active ? (
             <Breadcrumb
               segments={navigation.breadcrumbs}
               onToggleDropdown={navigation.toggleOpen}
@@ -159,7 +220,7 @@ export default function App() {
           ) : null}
         </div>
         <div className="header-stats">
-          {(() => {
+          {!dashboard.active && (() => {
             const mainAgents = state.agents.filter((a) => !a.isSubagent);
             const subs = state.agents.filter((a) => a.isSubagent);
             const workingSubs = subs.filter((a) => a.status === 'working').length;
@@ -186,100 +247,134 @@ export default function App() {
               </>
             );
           })()}
-          <span className="header-stat-divider" />
-          <span className="header-stat">
-            <span className="header-stat-value">{tasksByStatus.in_progress}</span> active
-          </span>
-          <span className="header-stat-divider" />
-          <span className="header-stat">
-            <span className="header-stat-value">{tasksByStatus.completed}</span>
-            <span className="header-stat-total">/{state.tasks.length}</span> done
-          </span>
-          {notifications.waitingAgents.length > 0 && (
+          {!dashboard.active && (
             <>
               <span className="header-stat-divider" />
-              <span className="header-waiting-badge">
-                {notifications.waitingAgents.length} waiting
+              <span className="header-stat">
+                <span className="header-stat-value">{tasksByStatus.in_progress}</span> active
               </span>
+              <span className="header-stat-divider" />
+              <span className="header-stat">
+                <span className="header-stat-value">{tasksByStatus.completed}</span>
+                <span className="header-stat-total">/{state.tasks.length}</span> done
+              </span>
+              {notifications.waitingAgents.length > 0 && (
+                <>
+                  <span className="header-stat-divider" />
+                  <span className="header-waiting-badge">
+                    {notifications.waitingAgents.length} waiting
+                  </span>
+                </>
+              )}
             </>
           )}
         </div>
-        {notifications.permission !== 'unsupported' && (
-          <button
-            className={`notification-toggle ${notifications.enabled ? 'active' : ''}`}
-            onClick={notifications.toggle}
-            title={
-              notifications.permission === 'denied'
-                ? 'Notifications blocked by browser'
-                : notifications.enabled
-                  ? 'Disable notifications'
-                  : 'Enable notifications for agent alerts'
-            }
-            disabled={notifications.permission === 'denied'}
-          >
-            {notifications.enabled ? '\uD83D\uDD14' : '\uD83D\uDD15'}
-          </button>
-        )}
-        <button
-          className="sidebar-toggle"
-          onClick={() => setSidebarOpen((v) => !v)}
-          title={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
-        >
-          {sidebarOpen ? '\u25B6' : '\u25C0'}
-        </button>
-      </header>
-      <nav className="mobile-tabs">
-        <button
-          className={`mobile-tab ${mobileTab === 'scene' ? 'active' : ''}`}
-          onClick={() => setMobileTab('scene')}
-        >
-          Scene
-        </button>
-        <button
-          className={`mobile-tab ${mobileTab === 'inbox' ? 'active' : ''}`}
-          onClick={() => setMobileTab('inbox')}
-        >
-          Inbox
-          {inbox.unreadCount > 0 && (
-            <span className="inbox-badge">{inbox.unreadCount}</span>
+        <div className="header-actions">
+          {showDashboardToggle && (
+            <button
+              className={`dashboard-toggle ${dashboard.active ? 'active' : ''}`}
+              onClick={handleToggleDashboard}
+              title={dashboard.active ? 'Exit multi-panel view' : 'View all sessions as panels'}
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <rect x="1" y="1" width="6" height="6" rx="1" stroke="currentColor" strokeWidth="1.5" fill={dashboard.active ? 'currentColor' : 'none'} />
+                <rect x="9" y="1" width="6" height="6" rx="1" stroke="currentColor" strokeWidth="1.5" fill={dashboard.active ? 'currentColor' : 'none'} />
+                <rect x="1" y="9" width="6" height="6" rx="1" stroke="currentColor" strokeWidth="1.5" fill={dashboard.active ? 'currentColor' : 'none'} />
+                <rect x="9" y="9" width="6" height="6" rx="1" stroke="currentColor" strokeWidth="1.5" fill={dashboard.active ? 'currentColor' : 'none'} />
+              </svg>
+            </button>
           )}
-        </button>
-        <button
-          className={`mobile-tab ${mobileTab === 'tasks' ? 'active' : ''}`}
-          onClick={() => setMobileTab('tasks')}
-        >
-          Tasks ({state.tasks.length})
-        </button>
-        <button
-          className={`mobile-tab ${mobileTab === 'messages' ? 'active' : ''}`}
-          onClick={() => setMobileTab('messages')}
-        >
-          Messages ({state.messages.length})
-        </button>
-      </nav>
+          {notifications.permission !== 'unsupported' && (
+            <button
+              className={`notification-toggle ${notifications.enabled ? 'active' : ''}`}
+              onClick={notifications.toggle}
+              title={
+                notifications.permission === 'denied'
+                  ? 'Notifications blocked by browser'
+                  : notifications.enabled
+                    ? 'Disable notifications'
+                    : 'Enable notifications for agent alerts'
+              }
+              disabled={notifications.permission === 'denied'}
+            >
+              {notifications.enabled ? '\uD83D\uDD14' : '\uD83D\uDD15'}
+            </button>
+          )}
+          {!dashboard.active && (
+            <button
+              className="sidebar-toggle"
+              onClick={() => setSidebarOpen((v) => !v)}
+              title={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+            >
+              {sidebarOpen ? '\u25B6' : '\u25C0'}
+            </button>
+          )}
+        </div>
+      </header>
+      {!dashboard.active && (
+        <nav className="mobile-tabs">
+          <button
+            className={`mobile-tab ${mobileTab === 'scene' ? 'active' : ''}`}
+            onClick={() => setMobileTab('scene')}
+          >
+            Scene
+          </button>
+          <button
+            className={`mobile-tab ${mobileTab === 'inbox' ? 'active' : ''}`}
+            onClick={() => setMobileTab('inbox')}
+          >
+            Inbox
+            {inbox.unreadCount > 0 && (
+              <span className="inbox-badge">{inbox.unreadCount}</span>
+            )}
+          </button>
+          <button
+            className={`mobile-tab ${mobileTab === 'tasks' ? 'active' : ''}`}
+            onClick={() => setMobileTab('tasks')}
+          >
+            Tasks ({state.tasks.length})
+          </button>
+          <button
+            className={`mobile-tab ${mobileTab === 'messages' ? 'active' : ''}`}
+            onClick={() => setMobileTab('messages')}
+          >
+            Messages ({state.messages.length})
+          </button>
+        </nav>
+      )}
       <div className="app-body">
-        <Scene
-          state={state}
-          className={isMobile && mobileTab !== 'scene' ? 'mobile-hidden' : undefined}
-          focusAgentId={focusAgentId}
-          onFocusTask={handleFocusTask}
-          groupedSessions={groupedSessions}
-          onSelectSession={handleSelectSession}
-        />
-        <Sidebar
-          state={state}
-          open={sidebarOpen}
-          className={isMobile && mobileTab === 'scene' ? 'mobile-hidden' : undefined}
-          forceTab={isMobile ? mobileSidebarTab : undefined}
-          onFocusAgent={handleFocusAgent}
-          onFocusTask={handleFocusTask}
-          highlightTaskId={highlightTaskId}
-          activeNotifications={inbox.activeNotifications}
-          historyNotifications={inbox.historyNotifications}
-          unreadCount={inbox.unreadCount}
-          onMarkRead={inbox.markRead}
-          onMarkAllRead={inbox.markAllRead}
-        />
+        {dashboard.active ? (
+          <DashboardGrid
+            panels={dashboard.panels}
+            onFocusPanel={dashboard.focusPanel}
+            onRemovePanel={handleRemovePanel}
+          />
+        ) : (
+          <>
+            <Scene
+              state={state}
+              className={isMobile && mobileTab !== 'scene' ? 'mobile-hidden' : undefined}
+              focusAgentId={focusAgentId}
+              onFocusTask={handleFocusTask}
+              groupedSessions={groupedSessions}
+              onSelectSession={handleSelectSession}
+            />
+            <Sidebar
+              state={state}
+              open={sidebarOpen}
+              className={isMobile && mobileTab === 'scene' ? 'mobile-hidden' : undefined}
+              forceTab={isMobile ? mobileSidebarTab : undefined}
+              onFocusAgent={handleFocusAgent}
+              onFocusTask={handleFocusTask}
+              highlightTaskId={highlightTaskId}
+              activeNotifications={inbox.activeNotifications}
+              historyNotifications={inbox.historyNotifications}
+              unreadCount={inbox.unreadCount}
+              onMarkRead={inbox.markRead}
+              onMarkAllRead={inbox.markAllRead}
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/packages/client/src/components/DashboardCell.tsx
+++ b/packages/client/src/components/DashboardCell.tsx
@@ -1,0 +1,53 @@
+import type { TeamState } from '@agent-viewer/shared';
+import { Scene } from './Scene';
+
+interface DashboardCellProps {
+  sessionId: string;
+  state: TeamState;
+  onFocus: (sessionId: string) => void;
+  onRemove: (sessionId: string) => void;
+}
+
+export function DashboardCell({ sessionId, state, onFocus, onRemove }: DashboardCellProps) {
+  const session = state.session;
+  const agentCount = state.agents.length;
+  const hasWaiting = state.agents.some((a) => a.waitingForInput);
+
+  const label = session
+    ? `${session.projectName}${session.gitBranch ? ` (${session.gitBranch})` : ''}`
+    : 'Loading...';
+
+  return (
+    <div
+      className={`dashboard-cell${hasWaiting ? ' dashboard-cell-waiting' : ''}`}
+      onDoubleClick={() => onFocus(sessionId)}
+    >
+      <div className="dashboard-cell-header">
+        <span className="dashboard-cell-label" title={label}>
+          {label}
+        </span>
+        <span className="dashboard-cell-meta">
+          {agentCount > 0 && (
+            <span className="dashboard-cell-agents">
+              {agentCount} {agentCount === 1 ? 'agent' : 'agents'}
+            </span>
+          )}
+          {hasWaiting && <span className="dashboard-cell-waiting-badge">!</span>}
+        </span>
+        <button
+          className="dashboard-cell-close"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove(sessionId);
+          }}
+          title="Remove panel"
+        >
+          x
+        </button>
+      </div>
+      <div className="dashboard-cell-scene">
+        <Scene state={state} />
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/DashboardGrid.tsx
+++ b/packages/client/src/components/DashboardGrid.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import type { DashboardPanel } from '../hooks/useDashboard';
+import { DashboardCell } from './DashboardCell';
+
+interface DashboardGridProps {
+  panels: DashboardPanel[];
+  onFocusPanel: (sessionId: string) => void;
+  onRemovePanel: (sessionId: string) => void;
+}
+
+/**
+ * Compute the optimal grid layout for N panels.
+ *
+ * Strategy:
+ * - 1 panel: 1 column (full width)
+ * - 2 panels: 2 columns side-by-side (landscape friendly)
+ * - 3-4 panels: 2 columns
+ * - 5-6 panels: 3 columns
+ * - 7-9 panels: 3 columns
+ * - 10+: 4 columns
+ *
+ * Panels maintain their insertion order (stable positioning).
+ * When a panel is removed, remaining panels don't shift around
+ * because CSS grid handles sparse placement naturally.
+ */
+function getGridColumns(count: number): number {
+  if (count <= 1) return 1;
+  if (count <= 4) return 2;
+  if (count <= 9) return 3;
+  return 4;
+}
+
+export function DashboardGrid({ panels, onFocusPanel, onRemovePanel }: DashboardGridProps) {
+  const columns = useMemo(() => getGridColumns(panels.length), [panels.length]);
+
+  if (panels.length === 0) {
+    return (
+      <div className="dashboard-empty">
+        <p>No panels active. Toggle dashboard mode to view all sessions.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="dashboard-grid"
+      style={{
+        gridTemplateColumns: `repeat(${columns}, 1fr)`,
+      }}
+    >
+      {panels.map((panel) => (
+        <DashboardCell
+          key={panel.sessionId}
+          sessionId={panel.sessionId}
+          state={panel.state}
+          onFocus={onFocusPanel}
+          onRemove={onRemovePanel}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/client/src/hooks/useDashboard.ts
+++ b/packages/client/src/hooks/useDashboard.ts
@@ -1,0 +1,176 @@
+import { useState, useCallback, useRef, useMemo } from 'react';
+import type { TeamState, SessionListEntry, DashboardSessionState } from '@agent-viewer/shared';
+import { applyMessage } from './useWebSocket';
+import type { WSMessage } from '@agent-viewer/shared';
+
+const EMPTY_STATE: TeamState = {
+  name: '',
+  agents: [],
+  tasks: [],
+  messages: [],
+};
+
+export interface DashboardPanel {
+  sessionId: string;
+  /** Stable insertion order index — used for grid positioning */
+  order: number;
+  /** The live state for this panel's session */
+  state: TeamState;
+}
+
+export interface DashboardState {
+  /** Whether dashboard mode is active */
+  active: boolean;
+  /** Ordered list of panels (stable order, only changes on add/remove) */
+  panels: DashboardPanel[];
+  /** Toggle dashboard mode on/off. When turning on, subscribes to all sessions. */
+  toggle: (sessions: SessionListEntry[]) => string[] | null;
+  /** Add a specific session as a new panel */
+  addPanel: (sessionId: string) => string[];
+  /** Remove a panel by session ID */
+  removePanel: (sessionId: string) => string[] | null;
+  /** Handle bulk initial states from server */
+  applyDashboardStates: (states: DashboardSessionState[]) => void;
+  /** Handle a per-session update from the server */
+  applyDashboardUpdate: (sessionId: string, inner: WSMessage) => void;
+  /** Click handler: enter single-view for a panel */
+  focusPanel: (sessionId: string) => void;
+  /** The session ID that was focused (for App to switch to single-view) */
+  focusedSessionId: string | null;
+  /** Clear the focused state after App processes it */
+  clearFocus: () => void;
+}
+
+/**
+ * Manages the multi-view dashboard state.
+ * Tracks which sessions are pinned as panels, their stable ordering,
+ * and their individual TeamState snapshots.
+ */
+export function useDashboard(): DashboardState {
+  const [active, setActive] = useState(false);
+  const [panels, setPanels] = useState<DashboardPanel[]>([]);
+  const [focusedSessionId, setFocusedSessionId] = useState<string | null>(null);
+  /** Monotonically increasing order counter for stable positioning */
+  const nextOrder = useRef(0);
+
+  const toggle = useCallback((sessions: SessionListEntry[]): string[] | null => {
+    let result: string[] | null = null;
+    setActive((prev) => {
+      if (prev) {
+        // Turning off — clear panels
+        setPanels([]);
+        nextOrder.current = 0;
+        return false;
+      } else {
+        // Turning on — create panels for all current sessions
+        const sessionIds = sessions.map((s) => s.sessionId);
+        const newPanels: DashboardPanel[] = sessionIds.map((sid, i) => {
+          const entry = sessions.find((s) => s.sessionId === sid);
+          return {
+            sessionId: sid,
+            order: i,
+            state: {
+              name: entry?.projectName || '',
+              agents: [],
+              tasks: [],
+              messages: [],
+            },
+          };
+        });
+        nextOrder.current = sessionIds.length;
+        setPanels(newPanels);
+        result = sessionIds;
+        return true;
+      }
+    });
+    return result;
+  }, []);
+
+  const addPanel = useCallback((sessionId: string): string[] => {
+    let allIds: string[] = [];
+    setPanels((prev) => {
+      if (prev.some((p) => p.sessionId === sessionId)) {
+        allIds = prev.map((p) => p.sessionId);
+        return prev;
+      }
+      const newPanel: DashboardPanel = {
+        sessionId,
+        order: nextOrder.current++,
+        state: EMPTY_STATE,
+      };
+      const updated = [...prev, newPanel];
+      allIds = updated.map((p) => p.sessionId);
+      return updated;
+    });
+    return allIds;
+  }, []);
+
+  const removePanel = useCallback((sessionId: string): string[] | null => {
+    let result: string[] | null = null;
+    setPanels((prev) => {
+      const filtered = prev.filter((p) => p.sessionId !== sessionId);
+      if (filtered.length === prev.length) return prev;
+      if (filtered.length === 0) {
+        setActive(false);
+        nextOrder.current = 0;
+        return [];
+      }
+      result = filtered.map((p) => p.sessionId);
+      return filtered;
+    });
+    return result;
+  }, []);
+
+  const applyDashboardStates = useCallback((states: DashboardSessionState[]) => {
+    setPanels((prev) => {
+      const stateMap = new Map(states.map((s) => [s.sessionId, s.team]));
+      return prev.map((panel) => {
+        const newState = stateMap.get(panel.sessionId);
+        if (newState) {
+          return { ...panel, state: newState };
+        }
+        return panel;
+      });
+    });
+  }, []);
+
+  const applyDashboardUpdate = useCallback((sessionId: string, inner: WSMessage) => {
+    setPanels((prev) => {
+      const idx = prev.findIndex((p) => p.sessionId === sessionId);
+      if (idx < 0) return prev;
+      const panel = prev[idx];
+      const newState = applyMessage(panel.state, inner);
+      if (newState === panel.state) return prev;
+      const updated = [...prev];
+      updated[idx] = { ...panel, state: newState };
+      return updated;
+    });
+  }, []);
+
+  const focusPanel = useCallback((sessionId: string) => {
+    setFocusedSessionId(sessionId);
+  }, []);
+
+  const clearFocus = useCallback(() => {
+    setFocusedSessionId(null);
+  }, []);
+
+  // Sort panels by stable order for rendering
+  const sortedPanels = useMemo(
+    () => [...panels].sort((a, b) => a.order - b.order),
+    [panels],
+  );
+
+  return {
+    active,
+    panels: sortedPanels,
+    toggle,
+    addPanel,
+    removePanel,
+    applyDashboardStates,
+    applyDashboardUpdate,
+    focusPanel,
+    focusedSessionId,
+    clearFocus,
+  };
+}

--- a/packages/client/src/hooks/useWebSocket.ts
+++ b/packages/client/src/hooks/useWebSocket.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import type { TeamState, SessionListEntry, GroupedSessionsList, WSMessage } from '@agent-viewer/shared';
+import type { TeamState, SessionListEntry, GroupedSessionsList, WSMessage, DashboardSessionState } from '@agent-viewer/shared';
 
 const EMPTY_STATE: TeamState = {
   name: '',
@@ -15,12 +15,22 @@ const EMPTY_GROUPED: GroupedSessionsList = {
 
 export type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting';
 
+/** Callbacks for routing dashboard messages to the dashboard hook */
+export interface DashboardCallbacks {
+  onDashboardStates: (states: DashboardSessionState[]) => void;
+  onDashboardUpdate: (sessionId: string, inner: WSMessage) => void;
+}
+
 export interface WebSocketState {
   team: TeamState;
   sessions: SessionListEntry[];
   groupedSessions: GroupedSessionsList;
   connectionStatus: ConnectionStatus;
   selectSession: (sessionId: string) => void;
+  /** Enter dashboard mode: subscribe to given session IDs */
+  setDashboard: (sessionIds: string[]) => void;
+  /** Register callbacks for dashboard messages */
+  setDashboardCallbacks: (cbs: DashboardCallbacks | null) => void;
 }
 
 export function useWebSocket(url: string): WebSocketState {
@@ -34,14 +44,32 @@ export function useWebSocket(url: string): WebSocketState {
   const hasLockedSession = useRef(false);
   /** Track the session ID the user is viewing, so we can re-send on reconnect */
   const lockedSessionId = useRef<string | undefined>(undefined);
+  /** Dashboard mode session IDs (for reconnection) */
+  const dashboardSessionIds = useRef<string[] | undefined>(undefined);
+  /** Ref to dashboard callbacks so the message handler can call them */
+  const dashboardCallbacksRef = useRef<DashboardCallbacks | null>(null);
 
   const selectSession = useCallback((sessionId: string) => {
     lockedSessionId.current = sessionId;
     hasLockedSession.current = true;
+    // Exit dashboard mode when selecting a single session
+    dashboardSessionIds.current = undefined;
     const ws = wsRef.current;
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: 'select_session', sessionId }));
     }
+  }, []);
+
+  const setDashboard = useCallback((sessionIds: string[]) => {
+    dashboardSessionIds.current = sessionIds.length > 0 ? sessionIds : undefined;
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'set_dashboard', sessionIds }));
+    }
+  }, []);
+
+  const setDashboardCallbacks = useCallback((cbs: DashboardCallbacks | null) => {
+    dashboardCallbacksRef.current = cbs;
   }, []);
 
   const connect = useCallback(() => {
@@ -54,6 +82,10 @@ export function useWebSocket(url: string): WebSocketState {
       if (!hasConnectedOnce.current) {
         // First connection: unlock so the first full_state locks us in
         hasLockedSession.current = false;
+      } else if (dashboardSessionIds.current) {
+        // Reconnection in dashboard mode: re-subscribe to all panels
+        console.log(`[ws] reconnect: re-entering dashboard with ${dashboardSessionIds.current.length} panels`);
+        ws.send(JSON.stringify({ type: 'set_dashboard', sessionIds: dashboardSessionIds.current }));
       } else if (lockedSessionId.current) {
         // Reconnection: immediately re-send our session selection.
         // The server created a new clientState with its own pick — override it.
@@ -94,6 +126,12 @@ export function useWebSocket(url: string): WebSocketState {
             break;
           case 'session_ended':
             setSessions((prev) => prev.filter((s) => s.sessionId !== msg.data.sessionId));
+            break;
+          case 'dashboard_states':
+            dashboardCallbacksRef.current?.onDashboardStates(msg.data.states);
+            break;
+          case 'dashboard_update':
+            dashboardCallbacksRef.current?.onDashboardUpdate(msg.data.sessionId, msg.data.inner);
             break;
           default:
             if (msg.type === 'full_state') {
@@ -139,7 +177,7 @@ export function useWebSocket(url: string): WebSocketState {
     };
   }, [connect]);
 
-  return { team: state, sessions, groupedSessions, connectionStatus, selectSession };
+  return { team: state, sessions, groupedSessions, connectionStatus, selectSession, setDashboard, setDashboardCallbacks };
 }
 
 export function applyMessage(state: TeamState, msg: WSMessage): TeamState {

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -295,6 +295,174 @@ html, body, #root {
   border-color: var(--color-text-dim);
 }
 
+/* Header actions group (dashboard toggle, notifications, sidebar toggle) */
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* Dashboard toggle button */
+.dashboard-toggle {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text-dim);
+  padding: 4px 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dashboard-toggle:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-dim);
+}
+
+.dashboard-toggle.active {
+  color: var(--color-gold);
+  border-color: var(--color-gold);
+  background: rgba(255, 215, 0, 0.1);
+}
+
+/* ========================================
+   DASHBOARD GRID (multi-panel view)
+   ======================================== */
+
+.dashboard-grid {
+  display: grid;
+  gap: 4px;
+  padding: 4px;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  background: var(--color-bg);
+}
+
+.dashboard-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-dim);
+  font-size: 13px;
+}
+
+/* Individual panel in the dashboard grid */
+.dashboard-cell {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-panel-bg);
+  overflow: hidden;
+  min-height: 0;
+  transition: border-color 0.2s;
+}
+
+.dashboard-cell:hover {
+  border-color: var(--color-text-dim);
+}
+
+.dashboard-cell-waiting {
+  border-color: rgba(255, 215, 0, 0.4);
+  animation: dashboard-cell-pulse 2s ease-in-out infinite;
+}
+
+@keyframes dashboard-cell-pulse {
+  0%, 100% { border-color: rgba(255, 215, 0, 0.4); }
+  50% { border-color: rgba(255, 215, 0, 0.7); }
+}
+
+.dashboard-cell-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+  min-height: 26px;
+}
+
+.dashboard-cell-label {
+  font-size: 11px;
+  font-weight: bold;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.dashboard-cell-meta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.dashboard-cell-agents {
+  font-size: 10px;
+  color: var(--color-text-dim);
+}
+
+.dashboard-cell-waiting-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-gold);
+  color: #1a1a2e;
+  font-size: 10px;
+  font-weight: bold;
+  animation: live-pulse 1.5s ease-in-out infinite;
+}
+
+.dashboard-cell-close {
+  background: none;
+  border: none;
+  color: var(--color-text-dim);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.dashboard-cell:hover .dashboard-cell-close {
+  opacity: 1;
+}
+
+.dashboard-cell-close:hover {
+  color: var(--color-red);
+}
+
+.dashboard-cell-scene {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+/* In dashboard mode, hide scene controls and detail popovers to keep panels clean */
+.dashboard-cell-scene .scene-controls {
+  display: none;
+}
+
+.dashboard-cell-scene .branch-sidebar {
+  display: none;
+}
+
 .app-body {
   display: flex;
   flex: 1;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -71,6 +71,8 @@ const wss = new WebSocketServer({ server, path: '/ws' });
 /** Per-client state: tracks which session each WebSocket client has selected */
 interface ClientState {
   selectedSessionId?: string;
+  /** Dashboard mode: client is subscribed to multiple sessions at once */
+  dashboardSessionIds?: string[];
 }
 const clientStates = new Map<WebSocket, ClientState>();
 
@@ -105,13 +107,69 @@ wss.on('connection', (ws: WebSocket) => {
   ws.send(JSON.stringify({ type: 'sessions_list', data: getClientSessionsList(ws) }));
   ws.send(JSON.stringify({ type: 'sessions_grouped', data: stateManager.getGroupedSessionsList(activeId) }));
 
+  /** Send dashboard_states for all subscribed sessions */
+  function sendDashboardStates(client: ClientState) {
+    const ids = client.dashboardSessionIds;
+    if (!ids || ids.length === 0) return;
+    const states = ids.map((sid) => ({
+      sessionId: sid,
+      team: stateManager.getStateForSession(sid),
+    }));
+    ws.send(JSON.stringify({ type: 'dashboard_states', data: { states } }));
+  }
+
+  /** Determine which dashboard session(s) an agent belongs to, for routing updates */
+  function getDashboardSessionsForAgent(client: ClientState, agentId: string): string[] {
+    const ids = client.dashboardSessionIds;
+    if (!ids) return [];
+    return ids.filter((sid) => stateManager.agentBelongsToSession(agentId, sid));
+  }
+
   // Subscribe to state changes — send per-client filtered views
   const unsubscribe = stateManager.subscribe((msg) => {
     if (ws.readyState !== WebSocket.OPEN) return;
 
     const client = clientStates.get(ws);
-    const clientSessionId = client?.selectedSessionId;
+    if (!client) return;
+    const clientSessionId = client.selectedSessionId;
+    const isDashboard = client.dashboardSessionIds && client.dashboardSessionIds.length > 0;
 
+    // --- Dashboard mode: wrap updates per-session ---
+    if (isDashboard) {
+      if (msg.type === 'full_state') {
+        sendDashboardStates(client);
+        const id = getClientActiveSessionId(ws);
+        ws.send(JSON.stringify({ type: 'sessions_list', data: getClientSessionsList(ws) }));
+        ws.send(JSON.stringify({ type: 'sessions_grouped', data: stateManager.getGroupedSessionsList(id) }));
+      } else if (msg.type === 'sessions_update' || msg.type === 'sessions_list' || msg.type === 'sessions_grouped') {
+        const id = getClientActiveSessionId(ws);
+        ws.send(JSON.stringify({ type: 'sessions_list', data: getClientSessionsList(ws) }));
+        ws.send(JSON.stringify({ type: 'sessions_grouped', data: stateManager.getGroupedSessionsList(id) }));
+      } else if (msg.type === 'session_started' || msg.type === 'session_ended') {
+        const id = getClientActiveSessionId(ws);
+        ws.send(JSON.stringify(msg));
+        ws.send(JSON.stringify({ type: 'sessions_list', data: getClientSessionsList(ws) }));
+        ws.send(JSON.stringify({ type: 'sessions_grouped', data: stateManager.getGroupedSessionsList(id) }));
+      } else if (msg.type === 'agent_removed') {
+        // Send removal wrapped for each dashboard session that might have had this agent
+        for (const sid of client.dashboardSessionIds!) {
+          ws.send(JSON.stringify({ type: 'dashboard_update', data: { sessionId: sid, inner: msg } }));
+        }
+      } else if (msg.type === 'agent_update' || msg.type === 'agent_added') {
+        const matchingSessions = getDashboardSessionsForAgent(client, msg.data.id);
+        for (const sid of matchingSessions) {
+          ws.send(JSON.stringify({ type: 'dashboard_update', data: { sessionId: sid, inner: msg } }));
+        }
+      } else {
+        // task_update, new_message — send to all dashboard sessions
+        for (const sid of client.dashboardSessionIds!) {
+          ws.send(JSON.stringify({ type: 'dashboard_update', data: { sessionId: sid, inner: msg } }));
+        }
+      }
+      return;
+    }
+
+    // --- Single-view mode (existing behavior) ---
     if (msg.type === 'full_state') {
       // Full state reset: send complete per-client filtered view
       const id = getClientActiveSessionId(ws);
@@ -161,10 +219,31 @@ wss.on('connection', (ws: WebSocket) => {
         const client = clientStates.get(ws);
         if (client) {
           client.selectedSessionId = msg.sessionId;
+          // If in dashboard mode, selecting a session exits dashboard
+          client.dashboardSessionIds = undefined;
         }
         // Send filtered state to only this client
         const id = getClientActiveSessionId(ws);
         ws.send(JSON.stringify({ type: 'full_state', data: getClientState(ws) }));
+        ws.send(JSON.stringify({ type: 'sessions_list', data: getClientSessionsList(ws) }));
+        ws.send(JSON.stringify({ type: 'sessions_grouped', data: stateManager.getGroupedSessionsList(id) }));
+      } else if (msg.type === 'set_dashboard' && Array.isArray(msg.sessionIds)) {
+        const sessionIds = msg.sessionIds.filter((id: unknown) => typeof id === 'string') as string[];
+        console.log(`[ws] Client entered dashboard mode: ${sessionIds.length} panels`);
+        const client = clientStates.get(ws);
+        if (client) {
+          client.dashboardSessionIds = sessionIds.length > 0 ? sessionIds : undefined;
+        }
+        if (sessionIds.length > 0) {
+          // Send bulk initial states for all panels
+          const states = sessionIds.map((sid) => ({
+            sessionId: sid,
+            team: stateManager.getStateForSession(sid),
+          }));
+          ws.send(JSON.stringify({ type: 'dashboard_states', data: { states } }));
+        }
+        // Always send updated sessions/grouped
+        const id = getClientActiveSessionId(ws);
         ws.send(JSON.stringify({ type: 'sessions_list', data: getClientSessionsList(ws) }));
         ws.send(JSON.stringify({ type: 'sessions_grouped', data: stateManager.getGroupedSessionsList(id) }));
       }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -180,6 +180,27 @@ export interface InboxState {
   activeCount: number;
 }
 
+// ============================================================================
+// DASHBOARD (multi-view) TYPES
+// ============================================================================
+
+/** State snapshot for a single dashboard cell */
+export interface DashboardSessionState {
+  sessionId: string;
+  team: TeamState;
+}
+
+/** Bulk initial state for all subscribed dashboard sessions */
+export interface DashboardStates {
+  states: DashboardSessionState[];
+}
+
+/** A per-session update wrapper used in dashboard mode */
+export interface DashboardUpdate {
+  sessionId: string;
+  inner: WSMessage;
+}
+
 export type WSMessage =
   | { type: 'full_state'; data: TeamState }
   | { type: 'agent_update'; data: AgentState }
@@ -191,4 +212,6 @@ export type WSMessage =
   | { type: 'sessions_grouped'; data: GroupedSessionsList }
   | { type: 'sessions_update'; data: { list: SessionListEntry[]; grouped: GroupedSessionsList } }
   | { type: 'session_started'; data: SessionInfo }
-  | { type: 'session_ended'; data: { sessionId: string } };
+  | { type: 'session_ended'; data: { sessionId: string } }
+  | { type: 'dashboard_states'; data: DashboardStates }
+  | { type: 'dashboard_update'; data: DashboardUpdate };


### PR DESCRIPTION
## Summary
This PR introduces a new dashboard mode that allows users to view and monitor multiple agent sessions simultaneously in a grid layout, complementing the existing single-session view.

## Key Changes

### Client-side
- **New `useDashboard` hook** (`packages/client/src/hooks/useDashboard.ts`): Manages dashboard state including active panels, their ordering, and individual TeamState snapshots. Provides methods to toggle dashboard mode, add/remove panels, and handle bulk state updates.

- **New dashboard components**:
  - `DashboardGrid`: Responsive grid layout that automatically adjusts columns based on panel count (1-4 columns)
  - `DashboardCell`: Individual panel displaying a session's Scene with header showing project name, agent count, and waiting indicators

- **Updated `App.tsx`**:
  - Integrated dashboard hook and wired callbacks to WebSocket for receiving dashboard updates
  - Added dashboard toggle button in header (visible when 2+ sessions exist)
  - Conditional rendering: shows dashboard grid when active, otherwise shows normal Scene + Sidebar
  - Hide AlertBar, navigation breadcrumb, and header stats when in dashboard mode
  - Double-click a panel to exit dashboard and focus that session

- **Updated `useWebSocket` hook**: Added `setDashboard()` and `setDashboardCallbacks()` methods to enable dashboard subscription and message routing

- **Styling** (`packages/client/src/styles/index.css`): Added comprehensive styles for dashboard grid, cells, headers, and interactive elements (toggle button, close button, waiting indicators)

### Server-side
- **Updated `packages/server/src/index.ts`**:
  - Added `dashboardSessionIds` to client state tracking for multi-session subscriptions
  - Implemented `sendDashboardStates()` to send bulk initial state for all subscribed sessions
  - Implemented `getDashboardSessionsForAgent()` to route agent updates to relevant dashboard sessions
  - Added dashboard message routing logic: wraps per-session updates in `dashboard_update` messages
  - Added `set_dashboard` message handler to switch between single-view and dashboard modes

### Shared types
- **Updated `packages/shared/src/types.ts`**: Added `DashboardSessionState`, `DashboardStates`, and `DashboardUpdate` types; extended `WSMessage` union with `dashboard_states` and `dashboard_update` message types

## Implementation Details

- **Stable panel ordering**: Uses a monotonically increasing counter to maintain insertion order even when panels are removed, preventing visual shifting
- **Responsive grid**: Automatically adjusts from 1-4 columns based on panel count
- **Efficient updates**: Dashboard updates are wrapped per-session, allowing the client to apply changes to the correct panel's state
- **Clean UI in dashboard mode**: Scene controls and branch sidebars are hidden in panels to reduce clutter
- **Visual feedback**: Waiting indicators pulse on panels with agents waiting for input; double-click to focus a panel and exit dashboard mode

https://claude.ai/code/session_01QMeXjJA7SQXYiBkjq1EWkN