### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in hook payload

### DIFF
--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -82,4 +82,20 @@ describe('validateHookEvent', () => {
     });
     expect(error).toMatch(/cwd is too long/);
   });
+
+  it('validates cwd path traversal components', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/absolute/path/../to/project',
+    });
+    expect(error).toMatch(/cwd must not contain traversal components/);
+  });
+
+  it('allows valid paths with redundant slashes', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/absolute//path/to/project',
+    });
+    expect(error).toBeNull();
+  });
 });

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -57,6 +57,10 @@ export function validateHookEvent(event: any): string | null {
     if (event.cwd.includes('\0')) {
         return 'cwd must not contain null bytes';
     }
+    const segments = event.cwd.split(/[/\\]/);
+    if (segments.includes('..')) {
+      return 'cwd must not contain traversal components';
+    }
   }
 
   return null;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path traversal components (`..`) were allowed within the `event.cwd` payload of hook events. Since `cwd` is used for `execFile` contexts when executing commands (like `git`), this presented a risk where compromised payloads could escape the intended working directory context, facilitating potential arbitrary command execution or access to untrusted file contexts.
🎯 **Impact:** Malicious hook payloads could escape the intended working directory context, causing the server to execute processes in arbitrary directories.
🔧 **Fix:** Added validation in `packages/server/src/validation.ts` to reject `cwd` paths that contain path traversal segments (`..`). Used a cross-platform approach by splitting the path string rather than string comparison with `path.normalize()` which causes cross-platform issues and rejects valid nested slashes.
✅ **Verification:** Added multiple unit tests covering this new condition and ran all unit tests, confirming there are no regressions.

---
*PR created automatically by Jules for task [17934071815148529576](https://jules.google.com/task/17934071815148529576) started by @goggledefogger*