### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in hook validation

### DIFF
--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -75,6 +75,14 @@ describe('validateHookEvent', () => {
     expect(error).toMatch(/cwd must not contain null bytes/);
   });
 
+  it('validates cwd path traversal components', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/path/with/../traversal',
+    });
+    expect(error).toMatch(/cwd must not contain path traversal components/);
+  });
+
   it('validates cwd length', () => {
     const error = validateHookEvent({
       hook_event_name: 'SessionStart',

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -57,6 +57,9 @@ export function validateHookEvent(event: any): string | null {
     if (event.cwd.includes('\0')) {
         return 'cwd must not contain null bytes';
     }
+    if (event.cwd.split(/[/\\]/).includes('..')) {
+      return 'cwd must not contain path traversal components';
+    }
   }
 
   return null;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential path traversal via `cwd` payload in the `/api/hook` endpoint. The current validation only prevented null bytes and enforced absolute paths, allowing crafted `cwd` inputs containing `..` to traverse outside intended directory boundaries.
🎯 Impact: As `cwd` is eventually passed to `child_process.execFile` in the hook handlers, a traversed directory could manipulate the execution context of spawned `git` commands or access unintended files.
🔧 Fix: Added a validation check using `p.split(/[/\\]/).includes('..')` to safely reject any traversal components, handling both POSIX and Windows separators.
✅ Verification: Covered by a new unit test in `packages/server/src/__tests__/validation.test.ts`. Run `npm run test:unit` to verify.

---
*PR created automatically by Jules for task [14450970888960855133](https://jules.google.com/task/14450970888960855133) started by @goggledefogger*