### PR TITLE
🛡️ Sentinel: [HIGH] Fix Cross-Site WebSocket Hijacking and missing CSP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2026-02-14 - Missing Origin Validation for Local WebSocket Server (CSWSH)
+**Vulnerability:** The local WebSocket server (`ws://127.0.0.1:3001/ws`) and Express HTTP endpoints lacked origin validation.
+**Learning:** Any malicious public website visited by the developer could connect to the local Agent Viewer server via WebSockets or make Cross-Site Request Forgery (CSRF) API calls, allowing attackers to read or manipulate local agent sessions. Local developer tools binding to loopback interfaces are inherently vulnerable to these attacks if `Origin` headers are not strictly checked.
+**Prevention:** Always implement origin validation on local web and WebSocket servers. Use the `cors` package for Express and the `verifyClient` callback in `ws` to ensure the `Origin` header matches `localhost` or `127.0.0.1` (or is absent for non-browser clients). Additionally, enforce a strict Content Security Policy (CSP) in the frontend application.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,6 +1260,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1310,7 +1319,6 @@
       "version": "25.2.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1849,6 +1857,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/csstype": {
@@ -2506,6 +2531,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -3188,7 +3222,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -3225,7 +3258,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -3574,7 +3606,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@agent-viewer/shared": "*",
+        "@types/cors": "^2.8.19",
         "chokidar": "^4.0.0",
+        "cors": "^2.8.6",
         "express": "^5.2.0",
         "ws": "^8.19.0"
       },

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' ws://localhost:* wss://localhost:* http://localhost:* ws://127.0.0.1:* wss://127.0.0.1:* http://127.0.0.1:*; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:;">
     <title>Agent Viewer Town</title>
   </head>
   <body>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@agent-viewer/shared": "*",
+    "@types/cors": "^2.8.19",
     "chokidar": "^4.0.0",
+    "cors": "^2.8.6",
     "express": "^5.2.0",
     "ws": "^8.19.0"
   },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,11 +1,13 @@
 import express from 'express';
 import { createServer } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
+import cors from 'cors';
 import { StateManager } from './state';
 import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
 import { validateHookEvent } from './validation';
 import { clearTouchBarStatus } from './touchbar';
+import { validateOrigin } from './origin';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -21,6 +23,18 @@ app.use((_req, res, next) => {
   res.setHeader('Referrer-Policy', 'no-referrer');
   next();
 });
+
+// Enable CORS for allowed origins to prevent CSWSH/CSRF
+app.use(cors({
+  origin: (origin, callback) => {
+    if (validateOrigin(origin)) {
+      callback(null, true);
+    } else {
+      // Memory: return callback(null, false) instead of returning Error for graceful rejection
+      callback(null, false);
+    }
+  },
+}));
 
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
@@ -66,7 +80,18 @@ app.get('/api/sessions', (_req, res) => {
 });
 
 // WebSocket server — per-client session tracking for multi-tab support
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({
+  server,
+  path: '/ws',
+  verifyClient: (info, callback) => {
+    const origin = info.origin;
+    if (validateOrigin(origin)) {
+      callback(true);
+    } else {
+      callback(false, 403, 'Forbidden');
+    }
+  }
+});
 
 /** Per-client state: tracks which session each WebSocket client has selected */
 interface ClientState {

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,0 +1,19 @@
+export function validateOrigin(origin: string | undefined): boolean {
+  // Allow requests without origin (e.g. from curl, CLI scripts, or our local hooks)
+  if (!origin) {
+    return true;
+  }
+
+  // Allow only localhost and 127.0.0.1 origins
+  try {
+    const url = new URL(origin);
+    if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') {
+      return true;
+    }
+  } catch {
+    // Invalid URL format
+    return false;
+  }
+
+  return false;
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Cross-Site WebSocket Hijacking and missing CSP

🚨 Severity: HIGH
💡 Vulnerability: The local WebSocket server and Express HTTP endpoints lacked origin validation, posing a potential Cross-Site WebSocket Hijacking (CSWSH) and CSRF risk. Furthermore, the client `index.html` lacked a strict Content Security Policy (CSP).
🎯 Impact: A malicious public website visited by the developer could connect to the local Agent Viewer server via WebSockets or make CSRF API calls, allowing attackers to read or manipulate local agent sessions.
🔧 Fix:
- Added origin validation to Express using the `cors` package.
- Added origin verification to the `ws` WebSocketServer via `verifyClient`.
- Implemented `validateOrigin` logic allowing only requests from `localhost`, `127.0.0.1`, or clients lacking an origin header (like `curl` or internal scripts).
- Added a strict CSP meta tag to `packages/client/index.html`.
✅ Verification: Ran unit tests and e2e tests. Also started the local frontend dev server and captured screenshots showing successful connection with CSP policies in place.

---
*PR created automatically by Jules for task [18284545150253731586](https://jules.google.com/task/18284545150253731586) started by @goggledefogger*