### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal risk in cwd validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2025-02-23 - Cross-Platform Path Traversal Detection
+**Vulnerability:** Path traversal detection failing on Windows when only checking for `/..`.
+**Learning:** Path validation in Node.js must account for cross-platform separators. Using `path.normalize(p) === p` can falsely reject valid paths on OSs like Windows due to separator conversion (e.g., `/` to `\`).
+**Prevention:** Detect path traversal safely by splitting the path string (`p.split(/[/\\]/)`) and checking for `..` segments.

--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -75,6 +75,22 @@ describe('validateHookEvent', () => {
     expect(error).toMatch(/cwd must not contain null bytes/);
   });
 
+  it('validates cwd path traversal', () => {
+    const error1 = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/path/to/../somewhere',
+    });
+    expect(error1).toMatch(/cwd must not contain path traversal components/);
+
+    // The previous `path.isAbsolute` check will also fail for `C:\\` on non-Windows
+    // so let's use an absolute path with the current platform path format, then add mixed separators.
+    const error2 = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/path\\to/../somewhere',
+    });
+    expect(error2).toMatch(/cwd must not contain path traversal components/);
+  });
+
   it('validates cwd length', () => {
     const error = validateHookEvent({
       hook_event_name: 'SessionStart',

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -57,6 +57,10 @@ export function validateHookEvent(event: any): string | null {
     if (event.cwd.includes('\0')) {
         return 'cwd must not contain null bytes';
     }
+    // Prevent path traversal
+    if (event.cwd.split(/[/\\]/).includes('..')) {
+      return 'cwd must not contain path traversal components (..)';
+    }
   }
 
   return null;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Potential path traversal vulnerability in `cwd` parameter from hook events not being thoroughly checked. While it's checked for an absolute path and null bytes, it could contain `..` relative elements, potentially enabling traversal attacks if the path is concatenated or used insecurely down the line. 
🎯 Impact: Could allow paths resolving outside the intended scope if the underlying code is vulnerable to directory traversal attacks utilizing `..`. Given that the `cwd` can eventually be supplied to commands (e.g. `git`), it is paramount to be thoroughly validated.
🔧 Fix: Implemented an exact cross-platform `..` path segment check leveraging `split(/[/\\]/)` to safely deny `cwd` inputs that contain traversal components.
✅ Verification: New unit tests in `packages/server/src/__tests__/validation.test.ts` verify that path traversal attempts with various slash configurations are rejected.

---
*PR created automatically by Jules for task [9945748741040857724](https://jules.google.com/task/9945748741040857724) started by @goggledefogger*