### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in hook cwd validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+## 2025-03-21 - Fix path traversal in hook cwd validation
+**Vulnerability:** Path traversal vulnerability in `/api/hook` payload validation where the `cwd` parameter was checked to be absolute and not contain null bytes but it allowed `..` path segments, enabling potential arbitrary directory access when used by execution methods (like `execFile`).
+**Learning:** `path.isAbsolute` does not inherently protect against path traversal segments within an absolute path.
+**Prevention:** Always validate against path traversal explicitly by looking for `..` segments using cross-platform separator parsing.

--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -75,6 +75,23 @@ describe('validateHookEvent', () => {
     expect(error).toMatch(/cwd must not contain null bytes/);
   });
 
+  it('validates path traversal (..) in cwd', () => {
+    const error1 = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/var/www/../app',
+    });
+    expect(error1).toMatch(/cwd must not contain path traversal segments/);
+
+    // Testing path validation requires matching the environment. When the server runs on Linux,
+    // path.isAbsolute('C:\\Windows') evaluates to false, so it triggers the absolute check.
+    // Testing purely the `..` validation using an absolute Unix path containing backslashes.
+    const error2 = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/var/www\\..\\app',
+    });
+    expect(error2).toMatch(/cwd must not contain path traversal segments/);
+  });
+
   it('validates cwd length', () => {
     const error = validateHookEvent({
       hook_event_name: 'SessionStart',

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -57,6 +57,10 @@ export function validateHookEvent(event: any): string | null {
     if (event.cwd.includes('\0')) {
         return 'cwd must not contain null bytes';
     }
+    // Prevent path traversal attacks (e.g. /home/user/../../etc/passwd)
+    if (event.cwd.split(/[/\\]/).includes('..')) {
+      return 'cwd must not contain path traversal segments (..)';
+    }
   }
 
   return null;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `cwd` parameter provided in hook payloads could contain path traversal segments (`..`). Although it checked if the path was absolute, this does not prevent traversal upwards (e.g. `/var/www/../../etc/passwd`). This value is used in executing arbitrary commands (like `git`).
🎯 Impact: This could potentially allow arbitrary directory access leading to command execution outside of intended directories.
🔧 Fix: Add validation in `/api/hook` payload validation logic to prevent path traversal vectors by properly checking if `..` segments exist in `event.cwd`.
✅ Verification: Ran `bun test` in `packages/server/src/__tests__/validation.test.ts` to verify `..` path segments correctly return validation errors.

---
*PR created automatically by Jules for task [17923680824807340998](https://jules.google.com/task/17923680824807340998) started by @goggledefogger*