### PR TITLE
🛡️ Sentinel: [HIGH] Prevent CSRF and Cross-Site WebSocket Hijacking

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+## 2025-05-18 - Prevent CSRF and Cross-Site WebSocket Hijacking (CSWSH)
+**Vulnerability:** Local development server lacked CORS restrictions and WebSocket connection origin validation, allowing potential cross-origin attacks from malicious sites loaded in the user's browser.
+**Learning:** Local dev servers bound to 127.0.0.1 remain vulnerable to browser-context attacks (like CSRF and CSWSH) if strict same-origin policies aren't explicitly enforced. The `ws` library does not validate origins by default.
+**Prevention:** Implement `verifyClient` for `ws` to explicitly check the `Origin` header against an allowlist (e.g., `localhost`/`127.0.0.1`), and use standard CORS middleware for Express endpoints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,6 +1260,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1849,6 +1859,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/csstype": {
@@ -2506,6 +2533,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -3188,7 +3224,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -3575,10 +3610,12 @@
       "dependencies": {
         "@agent-viewer/shared": "*",
         "chokidar": "^4.0.0",
+        "cors": "^2.8.6",
         "express": "^5.2.0",
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.0",
         "@types/ws": "^8.5.0",
         "tsx": "^4.21.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@agent-viewer/shared": "*",
     "chokidar": "^4.0.0",
+    "cors": "^2.8.6",
     "express": "^5.2.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
     "@types/ws": "^8.5.0",
     "tsx": "^4.21.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,11 +6,15 @@ import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
 import { validateHookEvent } from './validation';
 import { clearTouchBarStatus } from './touchbar';
+import { corsMiddleware, verifyClient } from './origin';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
 const app = express();
 const server = createServer(app);
+
+// CORS middleware
+app.use(corsMiddleware);
 
 // Security headers
 app.disable('x-powered-by');
@@ -66,7 +70,7 @@ app.get('/api/sessions', (_req, res) => {
 });
 
 // WebSocket server — per-client session tracking for multi-tab support
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({ server, path: '/ws', verifyClient });
 
 /** Per-client state: tracks which session each WebSocket client has selected */
 interface ClientState {

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,0 +1,29 @@
+import cors from 'cors';
+
+const LOCAL_ORIGIN_REGEX = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
+
+export const corsMiddleware = cors({
+  origin: (origin, callback) => {
+    // Allow requests with no origin (like mobile apps or curl requests)
+    if (!origin) {
+      return callback(null, true);
+    }
+    if (LOCAL_ORIGIN_REGEX.test(origin)) {
+      return callback(null, true);
+    }
+    return callback(null, false);
+  },
+});
+
+export const verifyClient = (info: { origin: string }, callback: (res: boolean, code?: number, message?: string) => void) => {
+  const origin = info.origin;
+  if (!origin) {
+    return callback(true);
+  }
+  if (LOCAL_ORIGIN_REGEX.test(origin)) {
+    return callback(true);
+  }
+  // Omitting the error code (e.g. 403) here to avoid a known Bun bug
+  // TypeError: undefined is not an object (evaluating 'http')
+  return callback(false);
+};


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The local development server (`@agent-viewer/server`) lacked restrictions on the domains allowed to send HTTP POST requests (CORS) or initiate WebSocket connections.
🎯 **Impact:** Malicious websites loaded in the user's browser could perform Cross-Site Request Forgery (CSRF) or Cross-Site WebSocket Hijacking (CSWSH) to interact with the local server, potentially injecting false hook events or stealing local state data.
🔧 **Fix:** 
- Installed the standard `cors` middleware and applied it to the Express app.
- Implemented a `verifyClient` callback for the `ws` library to validate the `Origin` header.
- Added an Origin regular expression (`/^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/`) to explicitly allow local domains while gracefully rejecting unauthorized ones.
✅ **Verification:**
- Successfully verified the application builds (`npm run build -w packages/server`).
- Successfully verified tests continue to pass without regression (`bun test`).

---
*PR created automatically by Jules for task [5343244542195403283](https://jules.google.com/task/5343244542195403283) started by @goggledefogger*