### PR TITLE
🛡️ Sentinel: [HIGH] Fix Cross-Site WebSocket Hijacking (CSWSH) and CSRF

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+## 2023-10-27 - Missing Cross-Origin Policies on Local Development Servers
+**Vulnerability:** Local development server running on `127.0.0.1` was vulnerable to Cross-Site WebSocket Hijacking (CSWSH) and Cross-Site Request Forgery (CSRF).
+**Learning:** Localbound servers are still reachable from the user's browser context. Without strict `Origin` header validation on both WebSocket connections and HTTP endpoints, malicious websites can blindly send requests or establish WebSocket connections to the local server, potentially compromising the local machine or reading sensitive session data.
+**Prevention:** Always enforce strict `Origin` validation using CORS middleware for HTTP endpoints and `verifyClient` for WebSocket servers, restricting access only to trusted local origins (e.g., `http://localhost:3000`).

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,19 +6,39 @@ import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
 import { validateHookEvent } from './validation';
 import { clearTouchBarStatus } from './touchbar';
+import { isValidOrigin } from './origin';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
 const app = express();
 const server = createServer(app);
 
-// Security headers
+// Security headers and CORS
 app.disable('x-powered-by');
-app.use((_req, res, next) => {
+app.use((req, res, next) => {
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
   res.setHeader('Referrer-Policy', 'no-referrer');
+
+  const origin = req.headers.origin;
+  if (!isValidOrigin(origin)) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
+  if (origin) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
+
+  // Handle preflight
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.status(204).end();
+    return;
+  }
+
   next();
 });
 
@@ -66,7 +86,17 @@ app.get('/api/sessions', (_req, res) => {
 });
 
 // WebSocket server — per-client session tracking for multi-tab support
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({
+  server,
+  path: '/ws',
+  verifyClient: (info, callback) => {
+    if (!isValidOrigin(info.origin)) {
+      callback(false, 403, 'Forbidden');
+      return;
+    }
+    callback(true);
+  }
+});
 
 /** Per-client state: tracks which session each WebSocket client has selected */
 interface ClientState {

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,0 +1,11 @@
+export const LOCAL_ORIGIN_REGEX = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
+
+/**
+ * Validates the origin of incoming requests.
+ * Allows requests without an origin (e.g., from local scripts/CLI tools)
+ * and restricts browser-based requests to local origins.
+ */
+export function isValidOrigin(origin: string | undefined): boolean {
+  if (!origin) return true;
+  return LOCAL_ORIGIN_REGEX.test(origin);
+}


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The local development server did not validate the `Origin` header for incoming HTTP or WebSocket requests. This left it vulnerable to Cross-Site WebSocket Hijacking (CSWSH) and Cross-Site Request Forgery (CSRF). Malicious websites accessed by the developer could blindly send requests or establish WebSocket connections to the server running on `127.0.0.1:3001`.
🎯 **Impact**: A malicious script in the browser could connect to the WebSocket and intercept sensitive multi-agent session data or potentially trigger server-side actions via unauthorized HTTP API calls.
🔧 **Fix**: 
- Added `packages/server/src/origin.ts` defining a strict `LOCAL_ORIGIN_REGEX`.
- Enforced origin validation in `packages/server/src/index.ts` using Express middleware, handling CORS preflight, and rejecting unauthorized origins with `403 Forbidden`.
- Implemented `verifyClient` on the `WebSocketServer` to reject non-local connections during the handshake.
✅ **Verification**: Run `npm run test:unit` from the root directory to ensure that validation does not break legitimate tests. Ensure that a standalone node script imitating a browser request with a malicious `Origin` header correctly receives a 403 Forbidden.

---
*PR created automatically by Jules for task [2833100088311280488](https://jules.google.com/task/2833100088311280488) started by @goggledefogger*