### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix shell injection risk by replacing exec with execFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2025-04-06 - Prevent Shell Injection with execFile
+**Vulnerability:** Shell injection risk from using `exec` in `packages/server/src/touchbar.ts`
+**Learning:** `child_process.exec` passes commands to a shell which can lead to shell injection vulnerabilities even with static commands.
+**Prevention:** Use `child_process.execFile` instead and pass arguments as an array to avoid invoking a shell.

--- a/packages/server/src/touchbar.ts
+++ b/packages/server/src/touchbar.ts
@@ -10,7 +10,7 @@ import { writeFile, readFile, access } from 'fs/promises';
 import { constants } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import type { AgentState } from '@agent-viewer/shared';
 
 const STATUS_FILE = '/tmp/agent-viewer-touchbar.json';
@@ -72,11 +72,11 @@ function buildMtmrConfig(background: string, title: string, titleColor = '#FFFFF
 }
 
 function ensureMtmrRunning(): void {
-  exec('pgrep -x MTMR', (err, stdout) => {
+  execFile('pgrep', ['-x', 'MTMR'], (err, stdout) => {
     if (!stdout.trim()) {
       // MTMR is not running — launch it
       console.log('[touchbar] Launching MTMR...');
-      exec('open -a MTMR', (launchErr) => {
+      execFile('open', ['-a', 'MTMR'], (launchErr) => {
         if (launchErr) {
           console.warn('[touchbar] Failed to launch MTMR:', launchErr.message);
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Shell injection risk from using `child_process.exec` with inputs in `packages/server/src/touchbar.ts` which evaluates commands within a shell environment.
🎯 Impact: While currently using static commands, future refactoring could introduce variables leading to arbitrary command execution on the host machine.
🔧 Fix: Replaced `exec` with `execFile` and passed command arguments as an array to invoke the executable directly without a shell layer.
✅ Verification: Ran full `bun test` suite successfully, verified typings and compiled successfully. Also verified no regressions on the client. Added Sentinel learning record.

---
*PR created automatically by Jules for task [7491181166574442343](https://jules.google.com/task/7491181166574442343) started by @goggledefogger*