### PR TITLE
🛡️ Sentinel: [HIGH] Fix Cross-Site WebSocket Hijacking and CSRF

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2024-04-09 - Cross-Site Request Forgery & Cross-Site WebSocket Hijacking
+**Vulnerability:** Local development servers, even when bound to 127.0.0.1, remain vulnerable to CSWSH and CSRF from malicious scripts running in the user's browser via different origins.
+**Learning:** Browsers implicitly send credentials/requests to localhost if origin checks are not explicitly enforced, enabling attackers to hijack WebSockets and make unauthorized API calls.
+**Prevention:** Always implement strict CORS policies returning 403 for unknown origins on HTTP endpoints and enforce `verifyClient` origin checks for WebSocket connections to reject untrusted connections.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,6 +1260,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1849,6 +1859,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/csstype": {
@@ -2506,6 +2533,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -3188,7 +3224,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -3575,10 +3610,12 @@
       "dependencies": {
         "@agent-viewer/shared": "*",
         "chokidar": "^4.0.0",
+        "cors": "^2.8.6",
         "express": "^5.2.0",
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.0",
         "@types/ws": "^8.5.0",
         "tsx": "^4.21.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@agent-viewer/shared": "*",
     "chokidar": "^4.0.0",
+    "cors": "^2.8.6",
     "express": "^5.2.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
     "@types/ws": "^8.5.0",
     "tsx": "^4.21.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,13 +4,41 @@ import { WebSocketServer, WebSocket } from 'ws';
 import { StateManager } from './state';
 import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
+import cors from 'cors';
 import { validateHookEvent } from './validation';
 import { clearTouchBarStatus } from './touchbar';
+import { isAllowedOrigin } from './origin';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
 const app = express();
 const server = createServer(app);
+
+// CORS configuration - only allow requests from localhost/127.0.0.1
+const corsOptions = {
+  origin: function (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) {
+    if (isAllowedOrigin(origin)) {
+      callback(null, true);
+    } else {
+      // Return false to gracefully omit CORS headers instead of throwing 500 error
+      callback(null, false);
+    }
+  },
+  methods: ['GET', 'POST'],
+  allowedHeaders: ['Content-Type'],
+};
+
+app.use(cors(corsOptions));
+
+// Fallback middleware to actively reject unauthorized origins
+app.use((req, res, next) => {
+  if (!isAllowedOrigin(req.headers.origin)) {
+    console.warn(`[security] Rejected request from unauthorized origin: ${req.headers.origin}`);
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  next();
+});
 
 // Security headers
 app.disable('x-powered-by');
@@ -66,7 +94,20 @@ app.get('/api/sessions', (_req, res) => {
 });
 
 // WebSocket server — per-client session tracking for multi-tab support
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({
+  server,
+  path: '/ws',
+  verifyClient: (info, callback) => {
+    // Validate WebSocket origin to prevent Cross-Site WebSocket Hijacking (CSWSH)
+    if (isAllowedOrigin(info.origin)) {
+      callback(true);
+    } else {
+      console.warn(`[security] Rejected WebSocket connection from unauthorized origin: ${info.origin}`);
+      // Returning false to reject. 403 status is optional in ws for verifyClient.
+      callback(false, 403, 'Forbidden');
+    }
+  }
+});
 
 /** Per-client state: tracks which session each WebSocket client has selected */
 interface ClientState {

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,0 +1,23 @@
+/**
+ * Security: Origin Validation
+ *
+ * Ensures that connections (HTTP and WebSocket) originate from trusted local sources.
+ * This mitigates Cross-Site Request Forgery (CSRF) and Cross-Site WebSocket Hijacking (CSWSH)
+ * where malicious websites attempt to interact with the local server.
+ */
+
+export function isAllowedOrigin(origin?: string): boolean {
+  // Allow requests without an origin (e.g., local scripts, curls, background workers)
+  if (!origin) {
+    return true;
+  }
+
+  try {
+    const url = new URL(origin);
+    // Allow only localhost, 127.0.0.1, and IPv6 localhost
+    return url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+  } catch (err) {
+    // If the origin cannot be parsed as a URL, reject it
+    return false;
+  }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The local development server running on localhost/127.0.0.1 was vulnerable to Cross-Site Request Forgery (CSRF) and Cross-Site WebSocket Hijacking (CSWSH). If a user visits a malicious website, the browser could implicitly send requests or establish WebSockets to the local server.
🎯 Impact: Attackers could interact with the application, hijack active sessions, or execute arbitrary API commands if the server is actively running.
🔧 Fix:
- Added `isAllowedOrigin` function to restrict requests strictly to `localhost`, `127.0.0.1`, and `[::1]`.
- Implemented HTTP `cors` middleware with an explicit fallback to actively return `403 Forbidden` for unknown origins.
- Implemented `verifyClient` on the `WebSocketServer` to reject unauthorized cross-origin connections before they establish.
- Documented findings in `.jules/sentinel.md`.
✅ Verification: Tested via unit tests using `bun test` and verified functionality visually against `npm run test:all`.

---
*PR created automatically by Jules for task [8583512893399203134](https://jules.google.com/task/8583512893399203134) started by @goggledefogger*