### PR TITLE
🛡️ Sentinel: [HIGH] Fix Cross-Site WebSocket Hijacking (CSWSH) Risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2024-05-24 - Cross-Site WebSocket Hijacking (CSWSH) and CSRF in Local Server
+**Vulnerability:** The Agent Viewer local server (`packages/server/src/index.ts`) accepted connections from any origin. This meant malicious websites visited by the developer could connect to the local WebSocket server (CSWSH) or make POST requests to `/api/hook` (CSRF), potentially reading state or injecting false hook data.
+**Learning:** Local development servers, even when bound safely to `127.0.0.1`, remain vulnerable to attacks from the browser context if strict cross-origin policies are not enforced.
+**Prevention:** Always implement `cors` middleware with strict origin checks for HTTP endpoints and validate the `origin` header via `verifyClient` in `ws` WebSocketServer configurations to restrict connections to trusted origins (e.g., `localhost`, `127.0.0.1`, `[::1]`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,6 +1260,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1849,6 +1859,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/csstype": {
@@ -2506,6 +2533,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -3188,7 +3224,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -3575,10 +3610,12 @@
       "dependencies": {
         "@agent-viewer/shared": "*",
         "chokidar": "^4.0.0",
+        "cors": "^2.8.6",
         "express": "^5.2.0",
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.0",
         "@types/ws": "^8.5.0",
         "tsx": "^4.21.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@agent-viewer/shared": "*",
     "chokidar": "^4.0.0",
+    "cors": "^2.8.6",
     "express": "^5.2.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
     "@types/ws": "^8.5.0",
     "tsx": "^4.21.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,11 +1,13 @@
 import express from 'express';
 import { createServer } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
+import cors from 'cors';
 import { StateManager } from './state';
 import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
 import { validateHookEvent } from './validation';
 import { clearTouchBarStatus } from './touchbar';
+import { isValidOrigin } from './origin';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -25,6 +27,28 @@ app.use((_req, res, next) => {
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: Date.now() });
+});
+
+// CORS enforcement
+const corsMiddleware = cors({
+  origin: (origin, callback) => {
+    if (isValidOrigin(origin)) {
+      callback(null, true);
+    } else {
+      callback(null, false);
+    }
+  },
+});
+app.use(corsMiddleware);
+
+// Fallback to strictly block non-CORS allowed origins
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (origin && !isValidOrigin(origin)) {
+    res.status(403).json({ error: 'Forbidden: Invalid Origin' });
+    return;
+  }
+  next();
 });
 
 // JSON body parsing for hook events
@@ -66,7 +90,19 @@ app.get('/api/sessions', (_req, res) => {
 });
 
 // WebSocket server — per-client session tracking for multi-tab support
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({
+  server,
+  path: '/ws',
+  verifyClient: (info, callback) => {
+    const origin = info.origin;
+    if (isValidOrigin(origin)) {
+      callback(true);
+    } else {
+      console.warn(`[ws] Rejected connection from invalid origin: ${origin}`);
+      callback(false, 403, 'Forbidden');
+    }
+  },
+});
 
 /** Per-client state: tracks which session each WebSocket client has selected */
 interface ClientState {

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,0 +1,11 @@
+export function isValidOrigin(origin: string | undefined): boolean {
+  if (!origin) return true; // Allow non-browser clients (e.g. bash hooks)
+
+  try {
+    const url = new URL(origin);
+    const hostname = url.hostname;
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+  } catch {
+    return false;
+  }
+}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,17 @@
+1. **Analyze Security Needs:**
+   Based on the provided memory and codebase exploration, there's a missing cross-origin security layer in `packages/server/src/index.ts`. The server (`packages/server`) implements CORS protection but currently lacks `cors` setup for Express HTTP endpoints and `verifyClient` origin validation for the WebSocket connection in `packages/server/src/index.ts`. The missing piece is protecting WebSocket connections from Cross-Site WebSocket Hijacking (CSWSH) and standard endpoints from CSRF.
+
+2. **Implement Security Enhancements in `packages/server/src/index.ts`:**
+   - Import `cors` module.
+   - Use `isValidOrigin` to validate HTTP CORS middleware. Fall back to 403 Forbidden manually for invalid origins.
+   - Add `verifyClient` to `wss = new WebSocketServer({ server, path: '/ws', verifyClient: ... })` to validate the `origin` header for WebSockets.
+
+3. **Verify Security Logic:**
+   - Ensure the server is securely locked down to localhost, 127.0.0.1, and [::1] only.
+   - Add a test or test the logic using bun tests.
+
+4. **Complete Pre-Commit Steps:**
+   - Check using `pnpm lint` and `pnpm test` equivalent, making sure testing pass.
+
+5. **Create Sentinel Security PR:**
+   - Create a Sentinel PR with "🛡️ Sentinel: [HIGH] Fix Cross-Site WebSocket Hijacking (CSWSH) Risk".


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The local development server in `packages/server` did not validate request origins. This lack of validation left the application vulnerable to Cross-Site WebSocket Hijacking (CSWSH) and Cross-Site Request Forgery (CSRF). Malicious websites visited by the developer could potentially read the state of their Claude session or push arbitrary hook events to the viewer via `localhost`.
🎯 **Impact:** Unauthorized remote access to local development data (Claude's hook events and sessions).
🔧 **Fix:** Introduced the `cors` package to enforce an origin whitelist (`localhost`, `127.0.0.1`, `[::1]`) for HTTP endpoints and added a `verifyClient` callback to the `ws` WebSocketServer to perform the same checks. Non-browser clients (which lack the `origin` header, e.g., the bash script hooks) are permitted safely without compromising browser context security.
✅ **Verification:** Unit tests passing (`bun test packages/server/src/__tests__/security.test.ts` and `validation.test.ts`).

---
*PR created automatically by Jules for task [15720366365354125903](https://jules.google.com/task/15720366365354125903) started by @goggledefogger*