### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal vulnerability in cwd hook input

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2025-02-14 - Path Traversal Vulnerability in cwd Hook Input
+**Vulnerability:** The `cwd` input in the server's webhook validation lacked a check for path traversal segments (e.g. `..`), meaning an attacker could craft an absolute path containing directory traversals that would bypass the `path.isAbsolute` check but resolve differently.
+**Learning:** Checking `path.isAbsolute(event.cwd)` is insufficient, because an absolute path can still be exploited via traversal sequences when passed to subsequent code handling files/commands. And `path.normalize` can convert valid Unix paths to Windows paths, rejecting them incorrectly.
+**Prevention:** Use a specific regular expression or `.split(/[/\\]/).includes('..')` on file paths provided by users/hooks before trusting them to prevent path traversal issues.

--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -75,6 +75,14 @@ describe('validateHookEvent', () => {
     expect(error).toMatch(/cwd must not contain null bytes/);
   });
 
+  it('validates cwd path traversal segments', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/path/to/../project',
+    });
+    expect(error).toMatch(/cwd must not contain path traversal segments/);
+  });
+
   it('validates cwd length', () => {
     const error = validateHookEvent({
       hook_event_name: 'SessionStart',

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -57,6 +57,9 @@ export function validateHookEvent(event: any): string | null {
     if (event.cwd.includes('\0')) {
         return 'cwd must not contain null bytes';
     }
+    if (event.cwd.split(/[/\\]/).includes('..')) {
+        return 'cwd must not contain path traversal segments';
+    }
   }
 
   return null;


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The server accepted `cwd` inputs in hook events that were absolute paths but still contained directory traversal components (`..`). These paths would pass the `path.isAbsolute()` check, potentially allowing an attacker to manipulate the file paths executed by the server (e.g. for `git` commands).
🎯 **Impact:** Potential unauthorized command execution context or directory traversal if an untrusted hook payload is processed.
🔧 **Fix:** Added a strict cross-platform split check (`.split(/[/\\]/).includes('..')`) to explicitly reject any `cwd` containing path traversals. Added associated unit tests. Recorded the learnings in the Sentinel journal.
✅ **Verification:** Unit tests added in `validation.test.ts` pass, ensuring that `/path/to/../project` is blocked while `/absolute/path` is allowed.

---
*PR created automatically by Jules for task [17491256365923846269](https://jules.google.com/task/17491256365923846269) started by @goggledefogger*