### PR TITLE
🛡️ Sentinel: [HIGH] Add CORS and WebSocket origin validation to prevent CSRF/CSWSH

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+
+## 2026-02-14 - Missing Origin Validation on Local Server
+**Vulnerability:** The local development server bound to `127.0.0.1` lacked strict CORS and WebSocket origin verification.
+**Learning:** Local servers are implicitly vulnerable to Cross-Site Request Forgery (CSRF) and Cross-Site WebSocket Hijacking (CSWSH). A malicious public website can use a victim's browser to send requests to `localhost` or open WebSockets to intercept data if explicit checks aren't enforced.
+**Prevention:** Always implement robust CORS middleware with explicit fallback logic for 403 blocks and use `verifyClient` to check origins on `ws` WebSocketServers to restrict access solely to allowed local domains (`localhost`, `127.0.0.1`, `[::1]`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1260,6 +1260,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1849,6 +1859,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/csstype": {
@@ -2506,6 +2533,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -3188,7 +3224,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -3575,10 +3610,12 @@
       "dependencies": {
         "@agent-viewer/shared": "*",
         "chokidar": "^4.0.0",
+        "cors": "^2.8.6",
         "express": "^5.2.0",
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.0",
         "@types/ws": "^8.5.0",
         "tsx": "^4.21.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,10 +11,12 @@
   "dependencies": {
     "@agent-viewer/shared": "*",
     "chokidar": "^4.0.0",
+    "cors": "^2.8.6",
     "express": "^5.2.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
     "@types/ws": "^8.5.0",
     "tsx": "^4.21.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import cors from 'cors';
 import { createServer } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { StateManager } from './state';
@@ -6,6 +7,7 @@ import { startWatcher } from './watcher';
 import { createHookHandler } from './hooks';
 import { validateHookEvent } from './validation';
 import { clearTouchBarStatus } from './touchbar';
+import { isAllowedOrigin } from './origin';
 
 const PORT = parseInt(process.env.PORT || '3001', 10);
 
@@ -19,6 +21,34 @@ app.use((_req, res, next) => {
   res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
   res.setHeader('Referrer-Policy', 'no-referrer');
+  next();
+});
+
+// CORS middleware
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (isAllowedOrigin(origin)) {
+        callback(null, true);
+      } else {
+        // We return false here to omit CORS headers, but we also use a custom
+        // middleware right after to forcefully return 403.
+        callback(null, false);
+      }
+    },
+    methods: ['GET', 'POST', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+    credentials: true,
+  })
+);
+
+// Explicit 403 Forbidden for unauthorized origins
+app.use((req, res, next) => {
+  if (!isAllowedOrigin(req.headers.origin)) {
+    console.warn(`[security] Blocked request from unauthorized origin: ${req.headers.origin}`);
+    res.status(403).json({ error: 'Forbidden: Unauthorized Origin' });
+    return;
+  }
   next();
 });
 
@@ -66,7 +96,20 @@ app.get('/api/sessions', (_req, res) => {
 });
 
 // WebSocket server — per-client session tracking for multi-tab support
-const wss = new WebSocketServer({ server, path: '/ws' });
+const wss = new WebSocketServer({
+  server,
+  path: '/ws',
+  verifyClient: (info, callback) => {
+    const origin = info.origin;
+    if (!isAllowedOrigin(origin)) {
+      console.warn(`[security] Blocked WebSocket connection from unauthorized origin: ${origin}`);
+      // Returning false for rejection can cause Bun issues, but standard Node handles it
+      callback(false, 403, 'Forbidden: Unauthorized Origin');
+      return;
+    }
+    callback(true);
+  },
+});
 
 /** Per-client state: tracks which session each WebSocket client has selected */
 interface ClientState {

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,0 +1,18 @@
+export function isAllowedOrigin(origin: string | undefined): boolean {
+  // Allow requests without an Origin header (e.g. non-browser clients)
+  if (origin === undefined) return true;
+
+  // Block sandboxed iframes explicitly
+  if (origin === 'null') return false;
+
+  try {
+    const url = new URL(origin);
+    return (
+      url.hostname === 'localhost' ||
+      url.hostname === '127.0.0.1' ||
+      url.hostname === '[::1]'
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The local Express server and WebSocket instance lacked strict origin validation. This exposes the application to Cross-Site Request Forgery (CSRF) and Cross-Site WebSocket Hijacking (CSWSH) because any malicious website visited by the user could potentially send background requests or open WebSocket connections to `127.0.0.1:3001` to fetch local application data or run local commands through the open port.
🎯 Impact: An attacker could potentially gain access to the local development data or compromise the user's workspace by driving actions through their browser on malicious sites.
🔧 Fix: Implemented strict origin checking logic in `packages/server/src/origin.ts`. Added the `cors` middleware to the Express app and added `verifyClient` to the `WebSocketServer` configuration, ensuring only requests from `localhost`, `127.0.0.1`, and `[::1]` (and headless non-browser clients) are permitted.
✅ Verification: Ran unit tests suite for the `/api/hook` endpoints to ensure existing functionality remains unhindered, explicitly checking edge cases in the origin logic.

---
*PR created automatically by Jules for task [3799384564566377962](https://jules.google.com/task/3799384564566377962) started by @goggledefogger*