### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal and injection in cwd

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Potential for arbitrary command execution context if hook inputs are compromised.
 **Learning:** The server uses `cwd` provided in hook payloads to execute `git` commands via `execFile`. While `execFile` avoids shell injection, the `cwd` option controls the working directory, which could be abused if the input source wasn't trusted (Claude Code).
 **Prevention:** Always validate `cwd` against an allowlist or ensure it resides within expected project paths, even for trusted internal tools.
+## 2025-04-26 - [Path Traversal & Command Injection in cwd]
+**Vulnerability:** The `/api/hook` endpoint accepted any absolute path for the `cwd` field without checking for path traversal (`..`) or shell metacharacters (`;&|$<>` etc.). It also improperly validated cross-platform absolute paths using `path.isAbsolute()` which behaves differently depending on the OS the server is running on.
+**Learning:** `path.isAbsolute()` is insufficient for security validation because cross-platform agents (e.g. Windows agents connecting to a Linux server) can send paths that bypass the check or are incorrectly interpreted. Also, relying solely on absolute path checks does not prevent path traversal if `..` segments are allowed, which could lead to command execution outside the intended workspace boundaries.
+**Prevention:** Always implement a dedicated `isSafePath` utility to enforce exact absolute path structures across platforms, block null bytes, block traversal markers (`..`), and sanitize/block shell metacharacters.

--- a/packages/server/src/__tests__/validation.test.ts
+++ b/packages/server/src/__tests__/validation.test.ts
@@ -64,7 +64,7 @@ describe('validateHookEvent', () => {
       hook_event_name: 'SessionStart',
       cwd: 'relative/path',
     });
-    expect(error).toMatch(/cwd must be an absolute path/);
+    expect(error).toMatch(/cwd must be a safe absolute path/);
   });
 
   it('validates cwd null bytes', () => {
@@ -72,7 +72,31 @@ describe('validateHookEvent', () => {
       hook_event_name: 'SessionStart',
       cwd: '/path/with/\0/byte',
     });
-    expect(error).toMatch(/cwd must not contain null bytes/);
+    expect(error).toMatch(/cwd must be a safe absolute path/);
+  });
+
+  it('validates cwd path traversal', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/absolute/path/../to/somewhere',
+    });
+    expect(error).toMatch(/cwd must be a safe absolute path/);
+  });
+
+  it('validates cwd shell metacharacters', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: '/absolute/path/&&/execute',
+    });
+    expect(error).toMatch(/cwd must be a safe absolute path/);
+  });
+
+  it('accepts valid Windows absolute path', () => {
+    const error = validateHookEvent({
+      hook_event_name: 'SessionStart',
+      cwd: 'C:\\valid\\windows\\path',
+    });
+    expect(error).toBeNull();
   });
 
   it('validates cwd length', () => {

--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -18,6 +18,33 @@ export const VALID_HOOK_EVENTS = new Set([
   'Notification',
 ]);
 
+export function isSafePath(p: string): boolean {
+  if (typeof p !== 'string') return false;
+
+  // Cross-platform absolute path validation
+  const isWindowsAbsolute = /^[a-zA-Z]:[\\/]/.test(p);
+  const isPosixAbsolute = p.startsWith('/');
+  if (!isWindowsAbsolute && !isPosixAbsolute) {
+    return false;
+  }
+
+  // Block null bytes
+  if (p.includes('\0')) return false;
+
+  // Block path traversal
+  const parts = p.split(/[/\\]/);
+  if (parts.includes('..')) {
+    return false;
+  }
+
+  // Block dangerous shell metacharacters (excluding valid path chars like (), [], ~)
+  if (/[;&|$`><*\?!\n\r]/.test(p)) {
+    return false;
+  }
+
+  return true;
+}
+
 export function validateHookEvent(event: any): string | null {
   if (!event || typeof event !== 'object') {
     return 'Event must be a JSON object';
@@ -51,11 +78,8 @@ export function validateHookEvent(event: any): string | null {
     if (event.cwd.length > 1024) {
       return 'cwd is too long (max 1024 chars)';
     }
-    if (!path.isAbsolute(event.cwd)) {
-      return 'cwd must be an absolute path';
-    }
-    if (event.cwd.includes('\0')) {
-        return 'cwd must not contain null bytes';
+    if (!isSafePath(event.cwd)) {
+      return 'cwd must be a safe absolute path without traversal or shell characters';
     }
   }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `/api/hook` endpoint accepted any absolute path for the `cwd` field without checking for path traversal (`..`) or dangerous shell metacharacters. `path.isAbsolute()` is also OS-dependent, potentially allowing bypasses on mixed-OS setups.
🎯 Impact: Attackers could supply maliciously crafted `cwd` values to bypass expected workspace boundaries via path traversal, or exploit edge cases in downstream path-to-command interpolations leading to command injection out of bound.
🔧 Fix: Replaced weak `path.isAbsolute` and explicit null byte checks with a comprehensive `isSafePath` function in `validation.ts`. This utility explicitly validates cross-platform absolute paths (`C:\` or `/`), and explicitly rejects `\0`, `..`, and dangerous shell metacharacters.
✅ Verification: Ran unit tests via `npx vitest run --config packages/server/vitest.config.ts`, added comprehensive traversal and payload tests which pass.

---
*PR created automatically by Jules for task [16239256333210265453](https://jules.google.com/task/16239256333210265453) started by @goggledefogger*