### PR TITLE
🧹 clean up unused imports in transcriptWatcher.ts

### DIFF
--- a/packages/server/src/watcher/transcriptWatcher.ts
+++ b/packages/server/src/watcher/transcriptWatcher.ts
@@ -1,5 +1,5 @@
 import chokidar from 'chokidar';
-import { basename, dirname } from 'path';
+import { basename } from 'path';
 import { stat as fsStat } from 'fs/promises';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -10,7 +10,6 @@ import {
   cleanProjectName,
   detectGitWorktree,
 } from '../parser';
-import { isReadable } from './utils';
 import {
   PROJECTS_DIR,
   IDLE_THRESHOLD_S,


### PR DESCRIPTION
🎯 **What:** Removed unused imports in `packages/server/src/watcher/transcriptWatcher.ts`. Specifically, `dirname` from the `path` module and `isReadable` from the local `./utils` module were removed.

💡 **Why:** Cleaning up unused imports reduces module dependencies, improves code readability, and helps maintain a clean codebase.

✅ **Verification:** 
- Used `grep` to confirm that the removed identifiers were not used anywhere else in the file.
- Ran `node --check` to verify the syntax of the modified file.
- Ran relevant unit tests using `bun test` to ensure no regressions in parser and state logic.
- Received a successful code review.

✨ **Result:** A cleaner and more maintainable `transcriptWatcher.ts` file.

---
*PR created automatically by Jules for task [6397484535622417407](https://jules.google.com/task/6397484535622417407) started by @goggledefogger*