### PR TITLE
🛡️ Sentinel: [HIGH] Enforce 403 Forbidden on Unauthorized CORS Origins

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The local development server (`packages/server`) bound to `127.0.0.1` lacked CORS middleware for HTTP endpoints and `Origin` header validation for WebSocket handshakes (`/ws`). This allowed malicious websites visited by the developer to potentially perform Cross-Site WebSocket Hijacking (CSWSH) and unauthorized cross-origin HTTP requests against the local server.
 **Learning:** Local servers, even when bound safely to loopback (`127.0.0.1`), are still vulnerable to attacks from the browser context if cross-origin policies are not enforced. Attackers can pivot through the developer's browser to send payloads or exfiltrate state.
 **Prevention:** Always implement `cors` middleware configured with a strict allowlist (e.g., `localhost` and `127.0.0.1`) and enforce identical validation in WebSocket server configurations via `verifyClient`. Return `false` in CORS origin callbacks rather than throwing an Error to handle unauthorized requests gracefully.
+
+## 2024-10-24 - CORS Strict Rejection Without Same-Origin Allowance Breaking Requests
+**Vulnerability:** Adding strict `403 Forbidden` response for unauthorized CORS origins blocked valid same-origin requests (e.g. from the application's own UI).
+**Learning:** Browsers dynamically assign the `Origin` header (often identical to the `Host` header) on same-origin POST/PUT/DELETE requests. A naive blocklist that relies solely on external `ALLOWED_ORIGINS` will erroneously reject the app's own traffic.
+**Prevention:** When introducing strict `403` fallbacks alongside `cors` middleware, actively check `req.headers.host` to ensure `origin.endsWith('//' + req.headers.host)` is explicitly permitted, preventing same-origin blocks.

--- a/packages/server/src/__tests__/security.test.ts
+++ b/packages/server/src/__tests__/security.test.ts
@@ -134,7 +134,20 @@ describe('Security: CORS and CSWSH Protection', () => {
         'Origin': 'https://malicious.com'
       }
     });
-    // Expected to not have CORS headers because the origin was rejected
+    // Now expecting 403 due to explicit fallback middleware
+    expect(res.status).toBe(403);
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('rejects request from "null" origin via CORS', async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/health`, {
+      method: 'GET',
+      headers: {
+        'Origin': 'null'
+      }
+    });
+    // Expecting 403 due to explicit fallback middleware blocking "null"
+    expect(res.status).toBe(403);
     expect(res.headers.get('access-control-allow-origin')).toBeNull();
   });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,20 @@ app.use(cors({
   methods: ['GET', 'POST'],
 }));
 
+// Explicit fallback middleware to enforce 403 Forbidden for unauthorized origins
+// The cors middleware will merely omit headers if origin is false, but we want to block the request.
+// We also allow requests where the Origin matches the Host header (same-origin).
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (origin !== undefined) {
+    const isSameOrigin = req.headers.host && origin.endsWith(`//${req.headers.host}`);
+    if (!isSameOrigin && !isAllowedOrigin(origin)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+  }
+  next();
+});
+
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: Date.now() });

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,5 +1,13 @@
 export function isAllowedOrigin(origin?: string): boolean {
-  if (!origin) return true;
+  if (origin === undefined) return true;
+  if (origin === 'null') return false;
+
+  const allowedOrigins = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
+    : ['http://127.0.0.1:5173', 'http://localhost:5173'];
+
+  if (allowedOrigins.includes(origin)) return true;
+
   try {
     const url = new URL(origin);
     return url.hostname === 'localhost' || url.hostname === '127.0.0.1';


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The local development server's CORS configuration lacked an active block mechanism, simply omitting CORS headers for unauthorized origins, potentially exposing the server to Cross-Site Request Forgery (CSRF) or Cross-Site WebSocket Hijacking (CSWSH) from malicious local websites or sandboxed environments (`Origin: null`).
🎯 Impact: Attackers could pivot through the developer's browser to send unauthorized payloads or exfiltrate state from the local server.
🔧 Fix:
- Enhanced `isAllowedOrigin` to explicitly block the string `'null'` origin.
- Added explicit fallback middleware in `index.ts` to actively reject unauthorized cross-origin requests with a `403 Forbidden` status.
- Added safe handling to allow same-origin requests (where `Origin` matches the `Host` header) to ensure internal routes still function correctly.
- Added comprehensive unit tests targeting specific CORS rejection behaviors and `null` origins.
✅ Verification: `npm run test:unit` passes, specifically validating that unauthorized requests are met with a `403` and not simply processed without headers.

---
*PR created automatically by Jules for task [5730923285917279732](https://jules.google.com/task/5730923285917279732) started by @goggledefogger*