### PR TITLE
🧹 [code health] Remove debug logging from teamTools.ts

### DIFF
--- a/packages/server/src/hooks/teamTools.ts
+++ b/packages/server/src/hooks/teamTools.ts
@@ -64,7 +64,6 @@ export function extractTeamCreate(stateManager: StateManager, event: PostToolUse
   const teamName = typeof input.team_name === 'string' ? input.team_name : '';
   if (!teamName) return;
 
-  console.log(`[hooks] TeamCreate detected: ${teamName} session=${sessionId.slice(0, 8)}`);
   stateManager.setTeamName(teamName);
 
   // If response contains member info, register agents
@@ -103,7 +102,6 @@ export function extractTeamCreate(stateManager: StateManager, event: PostToolUse
 
 /** Handle TeamDelete — clear team state */
 export function extractTeamDelete(stateManager: StateManager, sessionId: string) {
-  console.log(`[hooks] TeamDelete detected: session=${sessionId.slice(0, 8)}`);
   stateManager.clearTeamAgents();
   stateManager.addMessage({
     id: `hook-team-${Date.now()}`,
@@ -133,8 +131,6 @@ export function extractTaskCreate(stateManager: StateManager, event: PostToolUse
     if (match) taskId = match[1];
   }
   if (!taskId) taskId = `hook-${Date.now()}`;
-
-  console.log(`[hooks] TaskCreate: #${taskId} "${subject}" session=${sessionId.slice(0, 8)}`);
 
   stateManager.updateTask({
     id: taskId,
@@ -169,11 +165,9 @@ export function extractTaskUpdate(stateManager: StateManager, event: PostToolUse
     }
     if (status === 'deleted') {
       stateManager.removeTask(taskId);
-      console.log(`[hooks] TaskUpdate: #${taskId} deleted session=${sessionId.slice(0, 8)}`);
       return;
     }
     stateManager.updateTask(updated);
-    console.log(`[hooks] TaskUpdate: #${taskId} → ${status || 'updated'} owner=${owner || existing.owner || 'none'} session=${sessionId.slice(0, 8)}`);
 
     // Track currentTaskId on the owning agent
     const taskOwner = updated.owner || existing.owner;
@@ -196,8 +190,6 @@ export function extractTaskUpdate(stateManager: StateManager, event: PostToolUse
 
 export function handleTeammateIdle(stateManager: StateManager, event: TeammateIdleEvent, sessionId: string) {
   const teammateName = event.teammate_name;
-  const teamName = event.team_name;
-  console.log(`[hooks] TeammateIdle: ${teammateName || sessionId.slice(0, 8)} team=${teamName || 'unknown'}`);
 
   if (teammateName) {
     stateManager.updateAgentActivity(teammateName, 'idle');
@@ -210,9 +202,7 @@ export function handleTeammateIdle(stateManager: StateManager, event: TeammateId
 
 export function handleTaskCompleted(stateManager: StateManager, event: TaskCompletedEvent, sessionId: string) {
   const taskId = event.task_id;
-  const taskSubject = event.task_subject;
   const teammateName = event.teammate_name;
-  console.log(`[hooks] TaskCompleted: #${taskId} "${taskSubject}" by ${teammateName || sessionId.slice(0, 8)}`);
 
   // Update the task status if we're tracking it
   if (taskId) {


### PR DESCRIPTION
🎯 **What:** Removed debug `console.log` statements from `packages/server/src/hooks/teamTools.ts`.
💡 **Why:** To improve maintainability and reduce log noise, following code health best practices.
✅ **Verification:** Verified syntax using `node --check` and ran relevant unit tests. Verified that function exports remain intact.
✨ **Result:** Cleaned up `teamTools.ts` by removing 7 `console.log` calls and associated unused variables.

---
*PR created automatically by Jules for task [6522673957010666698](https://jules.google.com/task/6522673957010666698) started by @goggledefogger*