### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF bypass in cors middleware

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The local development server (`packages/server`) bound to `127.0.0.1` lacked CORS middleware for HTTP endpoints and `Origin` header validation for WebSocket handshakes (`/ws`). This allowed malicious websites visited by the developer to potentially perform Cross-Site WebSocket Hijacking (CSWSH) and unauthorized cross-origin HTTP requests against the local server.
 **Learning:** Local servers, even when bound safely to loopback (`127.0.0.1`), are still vulnerable to attacks from the browser context if cross-origin policies are not enforced. Attackers can pivot through the developer's browser to send payloads or exfiltrate state.
 **Prevention:** Always implement `cors` middleware configured with a strict allowlist (e.g., `localhost` and `127.0.0.1`) and enforce identical validation in WebSocket server configurations via `verifyClient`. Return `false` in CORS origin callbacks rather than throwing an Error to handle unauthorized requests gracefully.
+
+## 2024-05-18 - Express CORS Middleware Defense in Depth
+**Vulnerability:** The standard `cors()` middleware in Express only omits CORS headers for unauthorized origins, it doesn't actively block the request execution. This can allow CSRF attacks via "simple requests" (e.g., standard form submissions) that bypass preflight checks.
+**Learning:** Always use an explicit fallback middleware to return a 403 Forbidden for unauthorized origins to ensure the server actively drops the request instead of processing it.
+**Prevention:** Add a custom middleware after `cors()` that explicitly checks `req.headers.origin` and returns 403 for disallowed origins.

--- a/packages/server/src/__tests__/security.test.ts
+++ b/packages/server/src/__tests__/security.test.ts
@@ -134,7 +134,8 @@ describe('Security: CORS and CSWSH Protection', () => {
         'Origin': 'https://malicious.com'
       }
     });
-    // Expected to not have CORS headers because the origin was rejected
+    // Expected to return 403 Forbidden because the origin was rejected
+    expect(res.status).toBe(403);
     expect(res.headers.get('access-control-allow-origin')).toBeNull();
   });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,18 @@ app.use(cors({
   methods: ['GET', 'POST'],
 }));
 
+// Explicit fallback middleware to enforce 403 Forbidden for unauthorized origins
+// The cors middleware above omits headers for unauthorized origins but doesn't actively block the request.
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (!isAllowedOrigin(origin)) {
+    console.warn(`[http] Rejected request from unauthorized origin: ${origin}`);
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  next();
+});
+
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: Date.now() });


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The standard `cors` middleware in Express only omits CORS headers for unauthorized origins, but it does not actively block the request from executing on the server. This leaves the application vulnerable to Cross-Site Request Forgery (CSRF) via "simple" requests (e.g., standard form submissions) that do not trigger a preflight `OPTIONS` request.
🎯 **Impact:** An attacker could host a malicious site that submits unauthorized state-changing requests to the server, which would be processed despite the absence of CORS headers in the response.
🔧 **Fix:** Added an explicit fallback middleware immediately after the `cors` middleware to explicitly check `req.headers.origin`. If the origin is present but unauthorized, it actively returns a 403 Forbidden status, terminating the request before it reaches the API endpoints.
✅ **Verification:** Updated the existing security tests in `packages/server/src/__tests__/security.test.ts` to expect a 403 Forbidden status for disallowed origins, and verified that all tests (424) pass successfully via `vitest`.

---
*PR created automatically by Jules for task [17556387102604749590](https://jules.google.com/task/17556387102604749590) started by @goggledefogger*