### PR TITLE
🛡️ Sentinel: [HIGH] Fix Express CORS rejection handling and 'null' origin bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The local development server (`packages/server`) bound to `127.0.0.1` lacked CORS middleware for HTTP endpoints and `Origin` header validation for WebSocket handshakes (`/ws`). This allowed malicious websites visited by the developer to potentially perform Cross-Site WebSocket Hijacking (CSWSH) and unauthorized cross-origin HTTP requests against the local server.
 **Learning:** Local servers, even when bound safely to loopback (`127.0.0.1`), are still vulnerable to attacks from the browser context if cross-origin policies are not enforced. Attackers can pivot through the developer's browser to send payloads or exfiltrate state.
 **Prevention:** Always implement `cors` middleware configured with a strict allowlist (e.g., `localhost` and `127.0.0.1`) and enforce identical validation in WebSocket server configurations via `verifyClient`. Return `false` in CORS origin callbacks rather than throwing an Error to handle unauthorized requests gracefully.
+
+## 2026-06-01 - Express CORS Middleware Omission and Null Origin Bypass
+**Vulnerability:** The express `cors` middleware omits CORS headers for rejected origins, but does not block the request. This leaves the server open to attack from bypass techniques (e.g. `sandbox` iframes sending `origin: "null"`).
+**Learning:** Returning `false` in the `cors` package `origin` callback is insufficient for protection. Additionally, `new URL('null')` causes `cors` rejection, but `!origin` allowlisting in custom validation could mistakenly permit 'null' if not explicitly handled.
+**Prevention:** Add a fallback middleware after `cors` to explicitly return 403 for unauthorized origins (`req.headers.origin`). Also, explicitly block the string `'null'` in origin validation logic.

--- a/packages/server/src/__tests__/origin.test.ts
+++ b/packages/server/src/__tests__/origin.test.ts
@@ -19,4 +19,8 @@ describe('isAllowedOrigin', () => {
   it('denies invalid origins', () => {
     expect(isAllowedOrigin('invalid-url')).toBe(false);
   });
+
+  it('denies null origin', () => {
+    expect(isAllowedOrigin('null')).toBe(false);
+  });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,17 @@ app.use(cors({
   methods: ['GET', 'POST'],
 }));
 
+// Fallback middleware to actively reject unauthorized origins
+// Required because `cors` only omits headers rather than sending a 403 response when rejecting an origin
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (origin && !isAllowedOrigin(origin)) {
+    res.status(403).json({ error: 'Forbidden origin' });
+    return;
+  }
+  next();
+});
+
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: Date.now() });

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,5 +1,6 @@
 export function isAllowedOrigin(origin?: string): boolean {
   if (!origin) return true;
+  if (origin === 'null') return false;
   try {
     const url = new URL(origin);
     return url.hostname === 'localhost' || url.hostname === '127.0.0.1';


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Express CORS rejection handling and 'null' origin bypass

**🚨 Severity:** HIGH
**💡 Vulnerability:** The express `cors` middleware returns `callback(null, false)` for unauthorized origins, which only omits CORS headers but allows the request to reach the server handlers. Additionally, sandboxed iframes using `origin: "null"` could bypass checks if the `'null'` string isn't explicitly blocked.
**🎯 Impact:** Lack of server-side blocking enables Cross-Site Request Forgery (CSRF) style attacks (if the attacker doesn't need to read the response) against local servers bound to loopback.
**🔧 Fix:** 
1. Added an explicit 403 fallback middleware in `packages/server/src/index.ts` to actively block origins that fail `isAllowedOrigin`.
2. Updated `isAllowedOrigin` in `packages/server/src/origin.ts` to explicitly block the string `'null'`.
**✅ Verification:** Added tests in `packages/server/src/__tests__/origin.test.ts`. All test suites pass successfully.

---
*PR created automatically by Jules for task [16342213105764283829](https://jules.google.com/task/16342213105764283829) started by @goggledefogger*