### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure temporary file usage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The local development server (`packages/server`) bound to `127.0.0.1` lacked CORS middleware for HTTP endpoints and `Origin` header validation for WebSocket handshakes (`/ws`). This allowed malicious websites visited by the developer to potentially perform Cross-Site WebSocket Hijacking (CSWSH) and unauthorized cross-origin HTTP requests against the local server.
 **Learning:** Local servers, even when bound safely to loopback (`127.0.0.1`), are still vulnerable to attacks from the browser context if cross-origin policies are not enforced. Attackers can pivot through the developer's browser to send payloads or exfiltrate state.
 **Prevention:** Always implement `cors` middleware configured with a strict allowlist (e.g., `localhost` and `127.0.0.1`) and enforce identical validation in WebSocket server configurations via `verifyClient`. Return `false` in CORS origin callbacks rather than throwing an Error to handle unauthorized requests gracefully.
+
+## 2026-03-05 - Insecure Temporary Files in Scripts and Touch Bar Integration
+**Vulnerability:** Predictable filenames written to the world-writable `/tmp` directory for logging, PID files, application configuration, and Touch Bar synchronization states.
+**Learning:** Writing predictable files to `/tmp` allows local attackers to pre-create or symlink those files to arbitrarily overwrite critical system or user files when a higher-privileged or differently-privileged user runs the application (Symlink Attack).
+**Prevention:** Avoid `/tmp` for predictable state and lock files. Instead, use secure randomly generated files via `mktemp` for short-lived artifacts, or write state and log files to a user-controlled directory like `$HOME` (e.g. `~/.agent-viewer-dev.log`).

--- a/Launcher.applescript
+++ b/Launcher.applescript
@@ -6,7 +6,7 @@ end run
 
 on quit
 	try
-		do shell script "kill $(cat /tmp/agent-viewer-dev.pid)"
+		do shell script "kill $(cat ~/.agent-viewer-dev.pid)"
 	end try
 	try
 		do shell script "pkill -f 'concurrently.*packages/server'"

--- a/packages/server/src/touchbar.ts
+++ b/packages/server/src/touchbar.ts
@@ -13,7 +13,7 @@ import { join } from 'path';
 import { execFile } from 'child_process';
 import type { AgentState } from '@agent-viewer/shared';
 
-const STATUS_FILE = '/tmp/agent-viewer-touchbar.json';
+const STATUS_FILE = join(homedir(), '.agent-viewer-touchbar.json');
 const MTMR_CONFIG = join(homedir(), 'Library', 'Application Support', 'MTMR', 'items.json');
 const FLASH_INTERVAL_MS = 800;
 

--- a/scripts/install-mac-app.sh
+++ b/scripts/install-mac-app.sh
@@ -6,7 +6,7 @@ set -e
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_NAME="Agent Viewer Town"
 APP_PATH="/Applications/${APP_NAME}.app"
-TEMP_APPLESCRIPT="/tmp/Launcher.applescript"
+TEMP_APPLESCRIPT=$(mktemp)
 
 echo "🚀 Preparing macOS App installation..."
 
@@ -59,8 +59,8 @@ if ! command -v npm &> /dev/null; then
 fi
 
 cd "$APP_DIR"
-npm run dev </dev/null > /tmp/agent-viewer-dev.log 2>&1 &
-echo $! > /tmp/agent-viewer-dev.pid
+npm run dev </dev/null > "$HOME/.agent-viewer-dev.log" 2>&1 &
+echo $! > "$HOME/.agent-viewer-dev.pid"
 EOF
 chmod +x "$START_SCRIPT_PATH"
 

--- a/touchbar-dev/resources/scripts/agent_status.sh
+++ b/touchbar-dev/resources/scripts/agent_status.sh
@@ -2,7 +2,7 @@
 # Touch Bar button script — reads agent-viewer-town waiting status.
 # Returns formatted text for MTMR shellScriptTitledButton.
 
-STATUS_FILE="/tmp/agent-viewer-touchbar.json"
+STATUS_FILE="$HOME/.agent-viewer-touchbar.json"
 
 if [ ! -f "$STATUS_FILE" ]; then
     echo "🤖 —"

--- a/touchbar-dev/resources/scripts/pomodoro_tick.sh
+++ b/touchbar-dev/resources/scripts/pomodoro_tick.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Pomodoro timer display — reads state from /tmp/touchbar-pomodoro-state
-STATE_FILE="/tmp/touchbar-pomodoro-state"
-CMD_FILE="/tmp/touchbar-pomodoro-state.cmd"
+# Pomodoro timer display — reads state from ~/.touchbar-pomodoro-state
+STATE_FILE="$HOME/.touchbar-pomodoro-state"
+CMD_FILE="$HOME/.touchbar-pomodoro-state.cmd"
 WORK_SECONDS=1500  # 25 minutes
 BREAK_SECONDS=300  # 5 minutes
 

--- a/touchbar-dev/resources/templates/btt/pomodoro.json
+++ b/touchbar-dev/resources/templates/btt/pomodoro.json
@@ -19,7 +19,7 @@
       "BTTUUID": "TB-POMO-START",
       "BTTEnabled": 1,
       "BTTTouchBarButtonName": "Start",
-      "BTTTouchBarShellScriptString": "echo 'start' > /tmp/touchbar-pomodoro-state.cmd",
+      "BTTTouchBarShellScriptString": "echo 'start' > ~/.touchbar-pomodoro-state.cmd",
       "BTTTouchBarItemWidth": 60,
       "BTTOrder": 1
     },
@@ -29,7 +29,7 @@
       "BTTUUID": "TB-POMO-PAUSE",
       "BTTEnabled": 1,
       "BTTTouchBarButtonName": "Pause",
-      "BTTTouchBarShellScriptString": "echo 'pause' > /tmp/touchbar-pomodoro-state.cmd",
+      "BTTTouchBarShellScriptString": "echo 'pause' > ~/.touchbar-pomodoro-state.cmd",
       "BTTTouchBarItemWidth": 60,
       "BTTOrder": 2
     },
@@ -39,7 +39,7 @@
       "BTTUUID": "TB-POMO-RESET",
       "BTTEnabled": 1,
       "BTTTouchBarButtonName": "Reset",
-      "BTTTouchBarShellScriptString": "rm -f /tmp/touchbar-pomodoro-state /tmp/touchbar-pomodoro-state.cmd",
+      "BTTTouchBarShellScriptString": "rm -f ~/.touchbar-pomodoro-state ~/.touchbar-pomodoro-state.cmd",
       "BTTTouchBarItemWidth": 60,
       "BTTOrder": 3
     }

--- a/touchbar-dev/resources/templates/mtmr/pomodoro.json
+++ b/touchbar-dev/resources/templates/mtmr/pomodoro.json
@@ -20,7 +20,7 @@
     "title": "Start",
     "action": "shellScript",
     "executablePath": "/bin/bash",
-    "shellArguments": ["-c", "echo 'start' > /tmp/touchbar-pomodoro-state.cmd"],
+    "shellArguments": ["-c", "echo 'start' > ~/.touchbar-pomodoro-state.cmd"],
     "width": 60,
     "bordered": true,
     "background": "#00FF00"
@@ -30,7 +30,7 @@
     "title": "Pause",
     "action": "shellScript",
     "executablePath": "/bin/bash",
-    "shellArguments": ["-c", "echo 'pause' > /tmp/touchbar-pomodoro-state.cmd"],
+    "shellArguments": ["-c", "echo 'pause' > ~/.touchbar-pomodoro-state.cmd"],
     "width": 60,
     "bordered": true,
     "background": "#FFAA00"
@@ -40,7 +40,7 @@
     "title": "Reset",
     "action": "shellScript",
     "executablePath": "/bin/bash",
-    "shellArguments": ["-c", "rm -f /tmp/touchbar-pomodoro-state /tmp/touchbar-pomodoro-state.cmd"],
+    "shellArguments": ["-c", "rm -f ~/.touchbar-pomodoro-state ~/.touchbar-pomodoro-state.cmd"],
     "width": 60,
     "bordered": true,
     "background": "#FF0000"

--- a/touchbar-dev/run.sh
+++ b/touchbar-dev/run.sh
@@ -52,7 +52,7 @@ case "$COMMAND" in
         "$PYTHON" scripts/mtmr_generate.py apply --template agent-notifications "$@"
         echo ""
         echo "Touch Bar now shows agent waiting status!"
-        echo "The button polls /tmp/agent-viewer-touchbar.json every 2 seconds."
+        echo "The button polls ~/.agent-viewer-touchbar.json every 2 seconds."
         echo "Tap the button to bring Agent Viewer Town to the front."
         echo ""
         echo "To restore your previous Touch Bar: run.sh restore"

--- a/touchbar-dev/scripts/install_backend.sh
+++ b/touchbar-dev/scripts/install_backend.sh
@@ -35,18 +35,22 @@ elif [ "$BACKEND" = "mtmr" ]; then
         else
             echo "Homebrew install failed (likely download server issue). Trying GitHub release directly..."
             # GitHub Release fallback
-            curl -L -o /tmp/MTMR.dmg "https://github.com/Toxblh/MTMR/releases/download/v0.27/MTMR.0.27.dmg"
-            hdiutil attach /tmp/MTMR.dmg -nobrowse -quiet
+            TMP_DMG=$(mktemp)
+            curl -L -o "$TMP_DMG" "https://github.com/Toxblh/MTMR/releases/download/v0.27/MTMR.0.27.dmg"
+            hdiutil attach "$TMP_DMG" -nobrowse -quiet
             cp -R /Volumes/MTMR*/MTMR.app /Applications/
             hdiutil detach /Volumes/MTMR* -quiet
+            rm -f "$TMP_DMG"
             echo "✅ MTMR installed from GitHub."
         fi
     else
         # No Homebrew, use GitHub Release directly
-        curl -L -o /tmp/MTMR.dmg "https://github.com/Toxblh/MTMR/releases/download/v0.27/MTMR.0.27.dmg"
-        hdiutil attach /tmp/MTMR.dmg -nobrowse -quiet
+        TMP_DMG=$(mktemp)
+        curl -L -o "$TMP_DMG" "https://github.com/Toxblh/MTMR/releases/download/v0.27/MTMR.0.27.dmg"
+        hdiutil attach "$TMP_DMG" -nobrowse -quiet
         cp -R /Volumes/MTMR*/MTMR.app /Applications/
         hdiutil detach /Volumes/MTMR* -quiet
+        rm -f "$TMP_DMG"
         echo "✅ MTMR installed from GitHub."
     fi
     


### PR DESCRIPTION
This PR patches a critical security vulnerability involving the insecure use of predictable temporary file paths in the world-writable `/tmp` directory. 

Vulnerable files included:
- `scripts/install-mac-app.sh`
- `Launcher.applescript`
- `packages/server/src/touchbar.ts`
- `touchbar-dev/run.sh`
- `touchbar-dev/scripts/install_backend.sh`
- `touchbar-dev/resources/scripts/agent_status.sh`
- `touchbar-dev/resources/scripts/pomodoro_tick.sh`
- `touchbar-dev/resources/templates/btt/pomodoro.json`
- `touchbar-dev/resources/templates/mtmr/pomodoro.json`

These were mitigated by using dynamically generated names via `mktemp` for short-lived artifacts (e.g., AppleScript compilations, downloaded DMG files) and utilizing user-specific home directory paths (e.g., `~/.agent-viewer-dev.pid`, `~/.touchbar-pomodoro-state`) for predictable state/status files. 

An entry detailing the Insecure Temporary Files vulnerability has also been added to the `.jules/sentinel.md` journal. All tests pass locally.

---
*PR created automatically by Jules for task [18326889949496971767](https://jules.google.com/task/18326889949496971767) started by @goggledefogger*