### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF Risk by Enforcing Strict CORS Origin Blocking

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The local development server (`packages/server`) bound to `127.0.0.1` lacked CORS middleware for HTTP endpoints and `Origin` header validation for WebSocket handshakes (`/ws`). This allowed malicious websites visited by the developer to potentially perform Cross-Site WebSocket Hijacking (CSWSH) and unauthorized cross-origin HTTP requests against the local server.
 **Learning:** Local servers, even when bound safely to loopback (`127.0.0.1`), are still vulnerable to attacks from the browser context if cross-origin policies are not enforced. Attackers can pivot through the developer's browser to send payloads or exfiltrate state.
 **Prevention:** Always implement `cors` middleware configured with a strict allowlist (e.g., `localhost` and `127.0.0.1`) and enforce identical validation in WebSocket server configurations via `verifyClient`. Return `false` in CORS origin callbacks rather than throwing an Error to handle unauthorized requests gracefully.
+## 2026-06-25 - Strict CORS Origin Blocking Middleware Added
+**Vulnerability:** Simple cross-origin requests (CSRF) via unauthorized origins were not fully blocked.
+**Learning:** The `cors` package configured with `callback(null, false)` merely strips CORS headers but still allows the server to process the request, and the 'null' origin can be used by sandboxed iframes to bypass validation.
+**Prevention:** Always explicitly check for 'null' in origin validation, and apply a fallback middleware after the `cors` middleware to actively reject unauthorized origins with a 403 Forbidden status.

--- a/packages/server/src/__tests__/origin.test.ts
+++ b/packages/server/src/__tests__/origin.test.ts
@@ -12,6 +12,10 @@ describe('isAllowedOrigin', () => {
     expect(isAllowedOrigin('https://malicious.com')).toBe(false);
   });
 
+  it('denies "null" origin to block sandboxed iframes', () => {
+    expect(isAllowedOrigin('null')).toBe(false);
+  });
+
   it('allows undefined origin (e.g. non-browser clients)', () => {
     expect(isAllowedOrigin(undefined)).toBe(true);
   });

--- a/packages/server/src/__tests__/security.test.ts
+++ b/packages/server/src/__tests__/security.test.ts
@@ -136,5 +136,18 @@ describe('Security: CORS and CSWSH Protection', () => {
     });
     // Expected to not have CORS headers because the origin was rejected
     expect(res.headers.get('access-control-allow-origin')).toBeNull();
+    // Expected to be explicitly forbidden by fallback middleware
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects request from "null" origin', async () => {
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/health`, {
+      method: 'GET',
+      headers: {
+        'Origin': 'null'
+      }
+    });
+    expect(res.headers.get('access-control-allow-origin')).toBeNull();
+    expect(res.status).toBe(403);
   });
 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,18 @@ app.use(cors({
   methods: ['GET', 'POST'],
 }));
 
+// Fallback strict origin blocking middleware for unauthorized simple cross-origin requests
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  // If the origin is present but not allowed, actively reject the request
+  if (origin && !isAllowedOrigin(origin)) {
+    console.warn(`[cors] Rejected request from unauthorized origin: ${origin}`);
+    res.status(403).json({ error: 'Forbidden: unauthorized origin' });
+    return;
+  }
+  next();
+});
+
 // Health check endpoint
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: Date.now() });

--- a/packages/server/src/origin.ts
+++ b/packages/server/src/origin.ts
@@ -1,5 +1,6 @@
 export function isAllowedOrigin(origin?: string): boolean {
   if (!origin) return true;
+  if (origin === 'null') return false; // Block sandboxed iframes
   try {
     const url = new URL(origin);
     return url.hostname === 'localhost' || url.hostname === '127.0.0.1';


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The server's CORS configuration used `callback(null, false)` for unauthorized origins. While this strips CORS headers and prevents the browser from reading the response, it still allows the server to process the request (e.g., simple POST requests), which could lead to Cross-Site Request Forgery (CSRF). Additionally, the origin validation allowed the `'null'` string, which sandboxed iframes or local HTML files can use to bypass origin checks.
🎯 **Impact:** Malicious websites or iframes could potentially send state-altering requests to the local development server that would be executed despite failing CORS checks.
🔧 **Fix:** 
1. Explicitly blocked the `'null'` origin string in `isAllowedOrigin`.
2. Added a strict fallback middleware directly after the `cors` middleware that explicitly checks `req.headers.origin` and returns a `403 Forbidden` response to actively terminate the request if the origin is not allowed.
✅ **Verification:** Unit tests and security tests have been updated and run successfully (`npm run test:all`) to verify that the `'null'` origin and unauthorized origins now actively receive a `403` status.

---
*PR created automatically by Jules for task [1054280180170655934](https://jules.google.com/task/1054280180170655934) started by @goggledefogger*