### PR TITLE
fix(touchbar): refuse symlinked /tmp status file (O_NOFOLLOW, 0600)

### DIFF
--- a/packages/server/src/touchbar.ts
+++ b/packages/server/src/touchbar.ts
@@ -6,7 +6,7 @@
  * Also writes a status JSON file for any external consumers.
  */
 
-import { writeFile, readFile, access } from 'fs/promises';
+import { writeFile, readFile, access, open } from 'fs/promises';
 import { constants } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -19,6 +19,23 @@ const FLASH_INTERVAL_MS = 800;
 
 /** Marker we inject into the config so we know we own it */
 const AVT_MARKER = '__agent_viewer_town';
+
+/**
+ * Write STATUS_FILE without following a symlink at its final path component.
+ * STATUS_FILE is a predictable name in world-writable /tmp, so a local user could
+ * pre-plant a symlink there and redirect our write onto an arbitrary file. O_NOFOLLOW
+ * makes open() fail with ELOOP instead of clobbering the target; mode 0o600 keeps the
+ * file owner-only. Callers already treat write failure as non-critical.
+ */
+async function writeStatusFile(data: string): Promise<void> {
+  const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW;
+  const fh = await open(STATUS_FILE, flags, 0o600);
+  try {
+    await fh.writeFile(data);
+  } finally {
+    await fh.close();
+  }
+}
 
 export interface TouchBarStatus {
   waitingCount: number;
@@ -173,7 +190,7 @@ export async function updateTouchBarStatus(allAgents: Map<string, AgentState>): 
   if (comparable !== lastWrittenJson) {
     lastWrittenJson = comparable;
     try {
-      await writeFile(STATUS_FILE, json + '\n');
+      await writeStatusFile(json + '\n');
     } catch {
       // non-critical
     }
@@ -248,7 +265,7 @@ export async function clearTouchBarStatus(): Promise<void> {
 
   const status: TouchBarStatus = { waitingCount: 0, agents: [], timestamp: Date.now() };
   try {
-    await writeFile(STATUS_FILE, JSON.stringify(status) + '\n');
+    await writeStatusFile(JSON.stringify(status) + '\n');
   } catch {
     // non-critical
   }


### PR DESCRIPTION
## What changed

Both writes to the Touch Bar status file (`/tmp/agent-viewer-touchbar.json`) now go through a small `writeStatusFile()` helper that opens with `O_NOFOLLOW` and mode `0600`, instead of a plain `writeFile()`.

## Why

`STATUS_FILE` is a **predictable name in world-writable `/tmp`**. A local user could pre-plant a symlink at that path and redirect our write onto an arbitrary file the server's user can write (CWE-61 / CWE-377). `O_NOFOLLOW` makes `open()` fail with `ELOOP` rather than following the link; `0600` keeps the file owner-only. The existing call sites already treat a write failure as non-critical, so a refused (symlinked) write just skips silently — no behavior change on the normal path.

This is **low severity in practice** — a macOS-only, single-user personal dev tool — but the fix is a few lines and closes a real class of local temp-file attack.

## Verification

- `npm run build -w packages/server` — green
- Server unit tests: **475 passed** (no regression)
- Standalone runtime check of the flags: a planted symlink write is refused with `ELOOP`, the target file is left intact, a normal write to a fresh path works, and the resulting file mode is `0600`.

## Supersedes

This consolidates the ~15 duplicate **Sentinel temp-file / `/tmp` symlink** PRs (#146, #150, #152, #156, #157, #160, #161, #162, #169, #176, #178, #180, #181, #182, and the temp-file portions of #171) into one minimal, verified change. Those are being closed as superseded. The CORS/CSWSH and Windows exec-hijack fixes those PRs also touched already landed in #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
