### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Timing Attack in Token Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,7 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+## 2025-02-18 - [Secure Token Comparison]
+**Vulnerability:** Used strict equality (`===`) for comparing authentication tokens, which makes it vulnerable to timing attacks.
+**Learning:** In authentication systems, even for local/development scoped tools, string comparisons can leak information about the length and content of tokens via timing discrepancies.
+**Prevention:** Always hash tokens first and then use `crypto.timingSafeEqual` to avoid leaking token lengths and values.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,18 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false;
+  }
+  try {
+    // Hash both tokens to ensure they have the same length and avoid leaking
+    // the length of the expected token via timing.
+    const expectedHash = crypto.createHash('sha256').update(serverToken).digest();
+    const providedHash = crypto.createHash('sha256').update(token).digest();
+    return crypto.timingSafeEqual(expectedHash, providedHash);
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
**Severity:** MEDIUM

**Vulnerability:** The `validateToken` function in `packages/server/src/auth.ts` used strict equality (`===`) to compare the provided token with the expected server token.

**Impact:** This simple string comparison allows an attacker to perform a timing attack. By repeatedly sending requests and measuring the response time, an attacker can determine the length of the expected token and guess its characters one by one.

**Fix:** This pull request updates the `validateToken` function to hash both the expected and provided tokens using SHA-256 and then compares their hashes using Node's built-in `crypto.timingSafeEqual()`. Hashing both tokens first ensures they are of the same length, preventing the timing function from leaking the token length, and the constant-time comparison ensures that no information about the token's content is leaked via timing differences.

**Verification:**
The fix has been verified by running the test suite (`npm run test:all`), which includes tests for `auth.ts` and `security.test.ts`, and all tests passed successfully.

---
*PR created automatically by Jules for task [17485736218552021161](https://jules.google.com/task/17485736218552021161) started by @goggledefogger*