### PR TITLE
🛡️ Sentinel: [HIGH] Fix token comparison timing attack

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+
+## 2026-08-15 - Token Comparison Timing Attack Vulnerability
+**Vulnerability:** Comparing authentication tokens using strict equality (`===`) exposes the system to timing attacks, allowing attackers to infer the length and character-by-character content of the token based on the response time.
+**Learning:** Even internal or local services using simple bearer tokens are susceptible to timing attacks if the comparison bails out early on mismatched characters.
+**Prevention:** Always hash tokens first (e.g., using SHA-256) and use `crypto.timingSafeEqual` for the comparison to ensure a constant-time operation regardless of input validity or length.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,15 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false;
+  }
+
+  // Use crypto.timingSafeEqual and SHA-256 hash to prevent timing attacks and length leakage
+  const hashToken = crypto.createHash('sha256').update(token).digest();
+  const hashServerToken = crypto.createHash('sha256').update(serverToken).digest();
+
+  return crypto.timingSafeEqual(hashToken, hashServerToken);
 }
 
 /**


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Comparing authentication tokens using strict equality (`===`) exposes the system to timing attacks, allowing attackers to infer the length and character-by-character content of the token based on the response time.
🎯 **Impact:** An attacker could potentially bypass authentication if they can deduce the token, giving them unauthorized access to the application endpoints.
🔧 **Fix:** 
- Used `crypto.createHash('sha256')` to hash both the input `token` and the expected `serverToken`.
- Used `crypto.timingSafeEqual` to perform a constant-time comparison of the hashed tokens, effectively mitigating the timing attack and length leakage.
✅ **Verification:** 
- `npm run test:all` was executed and all unit, build, and end-to-end tests passed.

---
*PR created automatically by Jules for task [7126457082556053354](https://jules.google.com/task/7126457082556053354) started by @goggledefogger*