### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent timing attacks in token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,7 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+## 2024-07-08 - Use secure token comparison
+**Vulnerability:** Comparing authentication tokens using strict equality (`===`) allows timing attacks. Attackers could potentially deduce the token length or content by measuring the time it takes for the comparison to fail.
+**Learning:** Even internal or local services shouldn't use string equality for security tokens. JavaScript's `===` performs early exit on mismatch.
+**Prevention:** Always hash the tokens (e.g., using SHA-256) first and use `crypto.timingSafeEqual` for comparison instead of strict equality to prevent leaking token length or content via timing attacks.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,16 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false;
+  }
+  // Constant-time comparison to prevent timing attacks.
+  // We hash both the server token and the provided token using SHA-256
+  // before comparing to avoid leaking token length or content.
+  const hashServerToken = crypto.createHash('sha256').update(serverToken).digest();
+  const hashToken = crypto.createHash('sha256').update(token).digest();
+
+  return crypto.timingSafeEqual(hashServerToken, hashToken);
 }
 
 /**


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validateToken` function uses a strict equality check (`===`) to compare the provided token with the server's authentication token. Because string comparison short-circuits on the first mismatched character, this allows attackers to perform a timing attack. By measuring the response times to variations in the token, an attacker can theoretically infer the length and content of the `AUTH_TOKEN`, bypassing authentication.
🎯 Impact: Attackers could potentially deduce the authentication token, leading to unauthorized access to all protected endpoints (including state retrieval and hook ingestion) as well as the WebSocket endpoints.
🔧 Fix: Refactored the token comparison to hash both the `serverToken` and the provided `token` using SHA-256. These fixed-length (32-byte) hashes are then compared using `crypto.timingSafeEqual()`. This provides a constant-time comparison that does not short-circuit, thereby eliminating the timing channel.
✅ Verification: Successfully validated the updated syntax with `node --check`. Ran `npm run test:all` across all suites (including tests targeting `auth.ts`) which passed. This confirms that legitimate tokens are still correctly verified and unauthorized requests are appropriately rejected. Added an explicit log to the `.jules/sentinel.md` journal outlining the finding.

---
*PR created automatically by Jules for task [1717310382325906506](https://jules.google.com/task/1717310382325906506) started by @goggledefogger*