### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix timing attack vulnerability in token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,7 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+## 2025-02-28 - Prevent Timing Attacks in Token Validation
+**Vulnerability:** Strict equality (`===`) comparison in authentication token validation allowed timing attacks, potentially leaking token length and contents.
+**Learning:** `crypto.timingSafeEqual` prevents timing attacks, but strictly requires matching length buffers. A robust pattern to ensure lengths always match—without throwing errors that leak information—is to first hash both the provided and expected strings using SHA-256 before the constant-time comparison.
+**Prevention:** Avoid strict string equality (`===`) when verifying security tokens, secrets, or passwords. Always use hashing followed by constant-time string comparisons.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import { createHash, timingSafeEqual } from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,17 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+
+  if (!token) {
+    return false;
+  }
+
+  // Hash both tokens first to ensure equal length buffers for timingSafeEqual,
+  // which prevents timing attacks that could leak token length or content.
+  const expectedHash = createHash('sha256').update(serverToken).digest();
+  const providedHash = createHash('sha256').update(token).digest();
+
+  return timingSafeEqual(expectedHash, providedHash);
 }
 
 /**


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix timing attack vulnerability in token validation

🚨 Severity: CRITICAL
💡 Vulnerability: The `validateToken` function in `auth.ts` used a strict equality comparison (`===`) to compare the expected server token with the provided token. This enables a timing attack where an attacker can determine the length and contents of the correct token by measuring how long the comparison takes to fail.
🎯 Impact: An attacker could potentially bypass authentication by discovering the correct `AUTH_TOKEN` character by character.
🔧 Fix: Imported `createHash` and `timingSafeEqual` from the built-in `crypto` module. Updated the logic to first compute the SHA-256 hash of both tokens. This ensures that the buffers compared by `timingSafeEqual` are always exactly the same length (a strict requirement for `timingSafeEqual` to avoid throwing errors). Finally, compared the hashed buffers using `crypto.timingSafeEqual` to guarantee a constant-time comparison.
✅ Verification: Ran `npm run test:unit` confirming all authentication logic remains intact and existing token tests pass successfully without introducing regressions.

---
*PR created automatically by Jules for task [9264693186305652504](https://jules.google.com/task/9264693186305652504) started by @goggledefogger*