### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Timing Attack in validateToken

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,10 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+## 2025-02-26 - Timing Attack Vulnerability in Token Validation
+
+**Vulnerability:** The authentication check `token === serverToken` in `validateToken` was susceptible to timing attacks, theoretically leaking the token's length or content due to short-circuiting during strict string equality comparisons.
+
+**Learning:** While V8 string comparisons offer some mitigations against pure byte-by-byte timing attacks, relying on standard strict equality for sensitive authentication tokens is considered unsafe, especially in multi-tenant or globally-accessible Node.js server environments.
+
+**Prevention:** Always hash secrets/tokens with a cryptographically secure hash function (e.g., `crypto.createHash('sha256')`) before comparison, and use `crypto.timingSafeEqual` to compare the resulting constant-length buffers, preventing both length and content leakage.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,16 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false; // Token required but not provided
+  }
+
+  // Hash the tokens before comparison to ensure they are the same length
+  // and to prevent leaking token length/content via timing attacks.
+  const tokenHash = crypto.createHash('sha256').update(token).digest();
+  const serverTokenHash = crypto.createHash('sha256').update(serverToken).digest();
+
+  return crypto.timingSafeEqual(tokenHash, serverTokenHash);
 }
 
 /**

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
🚨 **Severity**: MEDIUM/HIGH
💡 **Vulnerability**: The authentication check `token === serverToken` in `validateToken` (in `packages/server/src/auth.ts`) was susceptible to timing attacks, theoretically leaking the token's length or content due to short-circuiting during strict string equality comparisons.
🎯 **Impact**: A remote attacker could potentially forge a token or deduce the server token by observing subtle differences in response times when brute-forcing the authentication string.
🔧 **Fix**: Imported `crypto` module, hashed both tokens using SHA-256 to ensure they are the same length, and replaced the strict equality check (`===`) with `crypto.timingSafeEqual(tokenHash, serverTokenHash)`.
✅ **Verification**: Verified using `npm run test:all`, confirming all tests (unit, build, e2e) pass securely without regression.

---
*PR created automatically by Jules for task [10864339864872737560](https://jules.google.com/task/10864339864872737560) started by @goggledefogger*