### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent timing attacks in auth token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+
+## 2026-07-11 - Prevent Timing Attacks in Token Validation
+**Vulnerability:** Authentication tokens were compared using strict equality (`===`), which leaks the time it takes to process the comparison based on the length of the matching prefix. This could allow attackers to guess the correct token byte-by-byte.
+**Learning:** Even internal or local services must use constant-time comparisons for secrets to prevent side-channel attacks.
+**Prevention:** Use `crypto.timingSafeEqual` for string comparisons involving secrets. Since `timingSafeEqual` requires buffers of the exact same length, hash both strings (e.g., with SHA-256) before comparison to ensure uniform buffer sizes and prevent length-based timing leaks.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,16 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+
+  if (!token) {
+    return false;
+  }
+
+  // Hash both tokens to prevent timing attacks and ensure constant length comparison
+  const serverTokenHash = crypto.createHash('sha256').update(serverToken).digest();
+  const providedTokenHash = crypto.createHash('sha256').update(token).digest();
+
+  return crypto.timingSafeEqual(serverTokenHash, providedTokenHash);
 }
 
 /**


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validateToken` function in `auth.ts` compared the provided authentication token against the server token using strict equality (`===`). This approach leaks information through the time it takes to perform the comparison, potentially allowing an attacker to guess the token byte-by-byte via a timing attack.
🎯 Impact: Attackers could theoretically forge valid authentication tokens by analyzing response times, thereby bypassing authentication mechanisms.
🔧 Fix: Replaced the strict equality check with `crypto.timingSafeEqual()`. To satisfy its requirement that both inputs be of identical length (and to avoid leaking token length via errors), both the server token and the provided token are now hashed using SHA-256 before comparison.
✅ Verification: Ran `npm run test:all` successfully. Unit tests verify that authentication logic remains functionally identical while enforcing constant-time comparisons securely.

---
*PR created automatically by Jules for task [16132110842928115392](https://jules.google.com/task/16132110842928115392) started by @goggledefogger*