### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack in token validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 .DS_Store
 *.tsbuildinfo
 .claude/settings.local.json
+test-results/
+playwright-report/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+
+## 2026-02-14 - Timing Attack in Authentication Token Validation
+**Vulnerability:** The `validateToken` function used strict equality (`===`) to compare the provided token with the configured `AUTH_TOKEN`, which is vulnerable to timing attacks that could leak token length or content.
+**Learning:** String comparison operators like `===` fail fast when comparing strings, allowing an attacker to deduce the correct token by measuring response times. It is not sufficient for secure token validation.
+**Prevention:** Use `crypto.timingSafeEqual` for comparing sensitive strings. Always hash both the provided and expected tokens (e.g., with SHA-256) before comparison to ensure they are the same length, which is required by `timingSafeEqual`.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,13 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false;
+  }
+  // Constant-time comparison to prevent timing attacks
+  const tokenHash = crypto.createHash('sha256').update(token).digest();
+  const serverTokenHash = crypto.createHash('sha256').update(serverToken).digest();
+  return crypto.timingSafeEqual(tokenHash, serverTokenHash);
 }
 
 /**


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The authentication logic in `packages/server/src/auth.ts` used strict equality (`===`) to compare the user-provided token against the server's `AUTH_TOKEN`. This exposes the endpoint to timing attacks where an attacker could deduce the token by measuring response times.
🎯 **Impact:** An attacker could potentially bypass the authentication mechanism by guessing the token one character at a time, allowing unauthorized access to sensitive server endpoints.
🔧 **Fix:** Replaced the strict equality check with a constant-time comparison using `crypto.timingSafeEqual`. To ensure the buffers are of the same length (a requirement for `timingSafeEqual`), both the input token and the configured token are hashed using SHA-256 before comparison.
✅ **Verification:** Ran `npm run test:all` and specific vitest tests (`src/__tests__/auth.test.ts`) to verify that the authentication logic remains functional and the vulnerability is mitigated. Also, test artifacts were excluded by updating `.gitignore` and learnings were documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3418069679863480748](https://jules.google.com/task/3418069679863480748) started by @goggledefogger*