### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent timing attacks in authentication

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+
+## 2024-05-18 - Prevent Timing Attacks in Authentication
+**Vulnerability:** The `validateToken` function compared tokens using strict equality (`===`). This string comparison can return early as soon as a character mismatch occurs, theoretically exposing the length and parts of the secret token through the time it takes to respond (timing attacks).
+**Learning:** Even internal server tokens, if checked via endpoints accessible over a network or websocket connection without constant-time logic, are theoretically susceptible to these attacks, which can allow an attacker to guess the token character by character.
+**Prevention:** Using `crypto.timingSafeEqual` with a hash (e.g. SHA-256) ensures constant-time comparison, meaning the response time is independent of how many characters correctly match the secret.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,15 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false;
+  }
+
+  // Use SHA-256 and timingSafeEqual to prevent timing attacks
+  const serverHash = crypto.createHash('sha256').update(serverToken).digest();
+  const tokenHash = crypto.createHash('sha256').update(token).digest();
+
+  return crypto.timingSafeEqual(serverHash, tokenHash);
 }
 
 /**


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `validateToken` function compared tokens using strict string equality (`===`). This approach allows an attacker to theoretically infer the length and characters of the secret token by measuring the time it takes for the server to reject incorrect guesses (timing attack).
🎯 **Impact:** If exploited, an attacker could bypass authentication by successfully guessing the `AUTH_TOKEN`, gaining unauthorized access to the application's sensitive endpoints and websocket connections.
🔧 **Fix:** Updated `validateToken` in `packages/server/src/auth.ts` to use `crypto.timingSafeEqual`. Both the provided token and the expected server token are hashed first using SHA-256 to ensure they are the exact same length (a requirement for `timingSafeEqual`) and then securely compared in constant time, eliminating the timing side-channel.
✅ **Verification:** Run `npm run test:all` to verify that authentication flows correctly accept valid tokens and reject invalid ones as before.

---
*PR created automatically by Jules for task [444517012434809830](https://jules.google.com/task/444517012434809830) started by @goggledefogger*