### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+
+## 2026-08-10 - Token Length/Content Leak via Timing Attacks
+**Vulnerability:** The authentication middleware used strict equality (`===`) to compare incoming tokens against the server token. This could allow an attacker to guess the token through timing attacks, as string comparison fails faster for strings of different lengths or earlier mismatched characters.
+**Learning:** Standard string comparisons in JavaScript are not constant-time. When comparing secrets like authentication tokens, small variations in execution time based on where the comparison fails can be measured by attackers to progressively guess the token contents or determine its length.
+**Prevention:** Always use `crypto.timingSafeEqual()` for comparing secret tokens. To ensure both inputs are of the same length and avoid leaking the actual token length, hash both tokens (e.g., with SHA-256) before performing the constant-time comparison.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,16 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false;
+  }
+
+  // Use crypto.timingSafeEqual with SHA-256 hashing for constant-time comparison
+  // Hashing first prevents leaking token length and ensures inputs to timingSafeEqual are same length
+  const tokenHash = crypto.createHash('sha256').update(token).digest();
+  const serverTokenHash = crypto.createHash('sha256').update(serverToken).digest();
+
+  return crypto.timingSafeEqual(tokenHash, serverTokenHash);
 }
 
 /**


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in token validation

🚨 Severity: HIGH
💡 Vulnerability: The authentication middleware used strict equality (`===`) to compare incoming tokens against the server token. This could allow an attacker to guess the token through timing attacks, as string comparison fails faster for strings of different lengths or earlier mismatched characters.
🎯 Impact: Attackers could potentially deduce the token length or content by measuring variations in execution time.
🔧 Fix: Updated `validateToken` in `packages/server/src/auth.ts` to use `crypto.timingSafeEqual` with SHA-256 hashing for constant-time comparison of tokens.
✅ Verification: Ran unit tests via `npm run test:unit`, which pass successfully.

---
*PR created automatically by Jules for task [9480403335525697724](https://jules.google.com/task/9480403335525697724) started by @goggledefogger*