### PR TITLE
🛡️ Sentinel: Fix Timing Attack in Token Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+
+## 2025-02-14 - Timing Attack in Token Validation
+**Vulnerability:** The server authentication mechanism in `packages/server/src/auth.ts` validated the provided token against `process.env.AUTH_TOKEN` using strict equality (`===`), making it vulnerable to timing attacks. An attacker could potentially infer the token length or content by measuring the time it takes for the comparison to return.
+**Learning:** Even internal or local authentication tokens should be compared securely to prevent timing-based extraction of secrets. Using strict equality leaks information because it short-circuits on the first mismatched character or length difference.
+**Prevention:** Always hash the tokens (e.g., using SHA-256) first and use `crypto.timingSafeEqual` for comparison instead of strict equality to prevent leaking token length or content via timing attacks.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
+import crypto from 'crypto';
 
 /**
  * Validates a token against the server's configured AUTH_TOKEN.
@@ -11,8 +12,13 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false;
+  }
+  // Use constant-time comparison to prevent timing attacks
+  const expectedHash = crypto.createHash('sha256').update(serverToken).digest();
+  const providedHash = crypto.createHash('sha256').update(token).digest();
+  return crypto.timingSafeEqual(expectedHash, providedHash);
 }
 
 /**


### PR DESCRIPTION
This PR resolves a timing attack vulnerability in `packages/server/src/auth.ts`.
By hashing both tokens and using `crypto.timingSafeEqual`, the comparison execution time remains constant regardless of string similarities. Additionally, it logs the learning to the Sentinel journal.

---
*PR created automatically by Jules for task [6884424183715777901](https://jules.google.com/task/6884424183715777901) started by @goggledefogger*