### PR TITLE
Fix timing attack vulnerability in token validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Use of predictable temporary files in world-writable directories (e.g., `/tmp/`) allows malicious local users to conduct symlink attacks, potentially overwriting arbitrary files owned by the executing user.
 **Learning:** Scripts and application logic like the Touch Bar integration and shell templates previously wrote files (e.g. `/tmp/agent-viewer-touchbar.json`, `/tmp/MTMR.dmg`) with predictable names. On multi-user systems, attackers can pre-create symlinks at these paths to corrupt or overwrite sensitive files with elevated privileges when the app writes to them.
 **Prevention:** Avoid writing to `/tmp/` with hardcoded names. Use user-owned home directory paths (e.g. `$HOME` or `~/`) for predictable application state, or use dynamically generated temp files via `mktemp` or `mkdtemp`.
+
+## 2026-10-25 - Timing Attack Vulnerability in Token Validation
+**Vulnerability:** The server used strict equality (`===`) in `validateToken` (`packages/server/src/auth.ts`) to compare the provided token with the server's `AUTH_TOKEN`, exposing a potential timing attack vulnerability where an attacker could theoretically guess the token length and contents.
+**Learning:** Simple string comparison operations can exit early when characters do not match, creating differences in execution time. While this may be acceptable in some low-security local environments, it is a poor practice for authentication tokens.
+**Prevention:** When validating authentication tokens, always hash the tokens (e.g., using SHA-256) first to obscure their original lengths, and then use `crypto.timingSafeEqual` for comparison to ensure constant-time evaluation and mitigate timing attacks.

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 import { IncomingMessage } from 'http';
 import { URL } from 'url';
@@ -11,8 +12,15 @@ export function validateToken(token?: string): boolean {
   if (!serverToken) {
     return true; // Auth disabled
   }
-  // Constant-time comparison could be better but strict equality is acceptable for this scope
-  return token === serverToken;
+  if (!token) {
+    return false;
+  }
+
+  // Hash tokens first to prevent leaking token length, then use timingSafeEqual
+  const expectedHash = crypto.createHash('sha256').update(serverToken).digest();
+  const providedHash = crypto.createHash('sha256').update(token).digest();
+
+  return crypto.timingSafeEqual(expectedHash, providedHash);
 }
 
 /**


### PR DESCRIPTION
This commit hardens the token validation logic by replacing strict string equality with a constant-time comparison via `crypto.timingSafeEqual`. By hashing the tokens with SHA-256 prior to comparison, we obscure the original lengths, allowing the constant-time operation to safely evaluate without throwing length-mismatch errors. This mitigates potential timing attacks against the `AUTH_TOKEN` validation mechanism.

Also appends a corresponding critical security learning to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [16387169828316400078](https://jules.google.com/task/16387169828316400078) started by @goggledefogger*